### PR TITLE
Invalidate emails

### DIFF
--- a/core/management/commands/invalidate.py
+++ b/core/management/commands/invalidate.py
@@ -1,0 +1,28 @@
+import csv
+from django.core.management.base import LabelCommand, CommandError
+from hosting.models import Profile
+
+
+class Command(LabelCommand):
+    help = """
+        Mark all emails from one or more CSV files as invalid.
+        Usage: ./manage.py validate suppression_*.csv
+        """
+
+    def handle_label(self, file_name, **options):
+        try:
+            csvfile = open(file_name, 'r')
+        except FileNotFoundError:
+            raise CommandError("The file %s was not found" % file_name)
+        with csvfile:
+            reader = csv.DictReader(csvfile)
+            try:
+                emails = list(row['email'] for row in reader)
+            except KeyError:
+                raise CommandError("CSV file must have an 'email' column header.")
+        self.action(file_name, emails)
+
+    def action(self, file_name, emails):
+        results = Profile.mark_invalid_emails(emails=emails)
+        for model, updated in results.items():
+            print(updated, model.__name__, 'emails marked as invalid from', file_name)

--- a/core/management/commands/validate.py
+++ b/core/management/commands/validate.py
@@ -1,0 +1,14 @@
+from .invalidate import Command as InvalidateCommand
+from hosting.models import Profile
+
+
+class Command(InvalidateCommand):
+    help = """
+        Mark all emails from one or more CSV files as valid.
+        Usage: ./manage.py validate suppression_*.csv
+        """
+
+    def action(self, file_name, emails):
+        results = Profile.mark_valid_emails(emails=emails)
+        for model, updated in results.items():
+            print(updated, model.__name__, 'emails marked as valid from', file_name)

--- a/hosting/forms.py
+++ b/hosting/forms.py
@@ -96,6 +96,7 @@ class ProfileCreateForm(ProfileForm):
     def save(self, commit=True):
         profile = super(ProfileForm, self).save(commit=False)
         profile.user = self.user
+        profile.email = self.user.email
         if commit:
             profile.save()
         return profile

--- a/hosting/templates/hosting/place_detail.html
+++ b/hosting/templates/hosting/place_detail.html
@@ -59,7 +59,7 @@
                                     <img src="{% static 'img/city_drink.svg' %}"
                                          onerror="this.onerror = null; this.src = this.src.replace(/\.svg$/, '.png');"
                                          alt="[&nbsp;{% trans "have a drink" %}&nbsp;]"
-                                         title="{% trans "I'd like to have a drink together" %}"
+                                         title="{% trans "I’d like to have a drink together" %}"
                                          style="width: 1.5em; height: 1.5em;" />
                                 {% endif %}
 
@@ -164,6 +164,21 @@
                         {% endif %}
                     </p>
                 </div>
+
+                {% if INVALID_PREFIX in place.owner.user.email %}
+                    <ul class="list-group phone-list col-xs-12 hidden-xs hidden-sm">
+                        {% for phone in place.owner.phones.all %}
+                            <li class="list-group-item list-vertical-align">
+                                <p class="details">
+                                    {{ phone.icon }}
+                                    <b class="number">{{ phone.number.as_international }}</b>
+                                    <br class="visible-xs-inline" />
+                                    <em class="comment">{{ phone.comments }}</em>
+                                </p>
+                            </li>
+                        {% endfor %}
+                    </ul>
+                {% endif %}
             {% else %}
                 {% include 'hosting/snippets/registration.html' %}
             {% endif %}
@@ -202,13 +217,34 @@
                 {% if place.conditions.all %}
                     {% include 'hosting/snippets/place_conditions.html' with conditions=place.conditions.all only %}
                 {% endif %}
+
+                {% if INVALID_PREFIX in place.owner.user.email %}
+                    <ul class="list-group phone-list col-xs-12 col-md-6">
+                        {% for phone in place.owner.phones.all %}
+                            <li class="list-group-item list-vertical-align">
+                                <p class="details">
+                                    {{ phone.icon }}
+                                    <b class="number">{{ phone.number.as_international }}</b>
+                                    <br class="visible-xs-inline" />
+                                    <em class="comment">{{ phone.comments }}</em>
+                                </p>
+                            </li>
+                        {% endfor %}
+                    </ul>
+                {% endif %}
             </div>
 
             <p class="col-xs-12">
                 {% if user.profile != place.owner %}
-                    <a href="{% url 'postman:write' place.owner.user.username %}" class="btn btn-primary btn-vert-space">
-                        <span class="glyphicon glyphicon-send"></span>&nbsp; {% trans "Write message" %}
-                    </a>
+                    {% if INVALID_PREFIX in place.owner.user.email %}
+                        <a href="#" class="btn btn-danger btn-vert-space disabled"
+                            title="{% trans "The user’s email address seems invalid" %}"
+                            data-toggle="tooltip">
+                    {% else %}
+                        <a href="{% url 'postman:write' place.owner.user.username %}" class="btn btn-primary btn-vert-space">
+                    {% endif %}
+                            <span class="glyphicon glyphicon-send"></span>&nbsp; {% trans "Write message" %}
+                        </a>
                 {% endif %}
                 {% if user.profile == place.owner or user.is_staff %}
                     <span class="btn-group btn-vert-space">

--- a/hosting/templates/hosting/profile_detail.html
+++ b/hosting/templates/hosting/profile_detail.html
@@ -79,10 +79,16 @@
                 <div class="btn-group edit-buttons">
                     {% block profile_edit_buttons %}
                         {% if profile != user.profile %}
-                            <a href="{% url 'postman:write' profile.user.username %}" class="btn btn-primary">
-                                <span class="glyphicon glyphicon-send"></span>&nbsp; 
-                                <strong>{% trans "Write message" %}</strong>
-                            </a>
+                            {% if INVALID_PREFIX in profile.user.email %}
+                                <a href="#" class="btn btn-danger disabled"
+                                   title="{% trans "The user’s email address seems invalid" %}"
+                                   data-toggle="tooltip" data-placement="bottom">
+                            {% else %}
+                                <a href="{% url 'postman:write' profile.user.username %}" class="btn btn-primary">
+                            {% endif %}
+                                    <span class="glyphicon glyphicon-send"></span>&nbsp; 
+                                    {% trans "Write message" %}
+                                </a>
                         {% endif %}
                         {% if profile == user.profile or role >= profile.SUPERVISOR %}
                             {% trans "Update user's details" as update_title %}
@@ -288,7 +294,7 @@
 
     {% block place_add_buttons %}{% endblock %}
 
-    {% if not view.public_view %}
+    {% if not view.public_view or INVALID_PREFIX in profile.user.email %}
         <hr />
 
         <h2 class="owner">{% trans "Phones" %}</h2>

--- a/hosting/templates/hosting/settings.html
+++ b/hosting/templates/hosting/settings.html
@@ -26,7 +26,14 @@
 
     <section class="callout callout-primary">
         <h4 id="{% trans "email" %}">{% trans "Email" %}</h4>
-        <samp><small>{{ profile.user.email }}</small></samp>
+        {% if INVALID_PREFIX in profile.user.email %}
+            <span class="email text-danger" title="{% trans "invalid email"%}" data-toggle="tooltip">
+                {{ profile.user.email|cut:INVALID_PREFIX }}
+                <span class="glyphicon glyphicon-warning-sign"></span>
+            </span>
+        {% else %}
+            <samp><small>{{ profile.user.email }}</small></samp>
+        {% endif %}
         {% if role == profile.OWNER %}
             <a href="{% url 'email_update' profile.user.pk %}" class="btn btn-default">
                 {% trans "Update system email" %}
@@ -42,7 +49,14 @@
             <a href="#profile-email" class="btn btn-default btn-xs" data-toggle="collapse" >{% trans "Other email?" %}</a>
             <div id="profile-email" class="collapse">
                 {% trans "no email" as no_email %}
-                <samp><small>{% firstof profile.email no_email %}</small></samp>
+                {% if INVALID_PREFIX in profile.email %}
+                    <span class="email text-danger" title="{% trans "invalid email"%}" data-toggle="tooltip">
+                        {{ profile.email|cut:INVALID_PREFIX }}
+                        <span class="glyphicon glyphicon-warning-sign"></span>
+                    </span>
+                {% else %}
+                    <samp><small>{% firstof profile.email no_email %}</small></samp>
+                {% endif %}
                 <a href="{% url 'profile_email_update' profile.pk profile.user.username|slugify %}?next={{ request.get_full_path|urlencode }}" class="btn btn-default">
                     {% trans "Update profile email" %}
                 </a>

--- a/pasportaservo/static/css/pasportaservo.css
+++ b/pasportaservo/static/css/pasportaservo.css
@@ -501,6 +501,7 @@ header:not(.home) #subtitle,
     opacity: 0;
 }
 
+.btn.disabled { pointer-events: auto; } /* Bootstrap hack for tooltip */
 
 /* Bootstrap Callout */
 


### PR DESCRIPTION
La reputacio de la retpoŝto en SendGrid draste malaltiĝas (~87%), kaj verŝajne estas parte pro tio ke ni sendas mesaĝojn al nevalidaj adresoj. 

Tiu fandpeto estas unua paŝo por malebligi uzanton sendi mesaĝon al alia uzanto kiu ne havas validan retadreson.

Vidu #69 
Kiel ekcepto, tiam oni afiŝas la telefonnumerojn sed estas.