### PR TITLE
Uzantoj kun retadreso markita nefunkcianta ne povas re-agordi sian pasvorton

### DIFF
--- a/core/templates/email/password_reset.html
+++ b/core/templates/email/password_reset.html
@@ -22,5 +22,5 @@
 {% block call_to_action %}
     {% url 'password_reset_confirm' uidb64=uid token=token as url %}
     {% blocktrans asvar text %}Choose password{% endblocktrans %}
-    {% include "email/button.html" %}
+    {% include "email/snippets/button.html" %}
 {% endblock %}

--- a/core/templates/email/password_reset.html
+++ b/core/templates/email/password_reset.html
@@ -3,7 +3,9 @@
 {% block heading %}{% trans "Password reset" %}{% endblock %}
 
 {% block preheader %}
-    {% blocktrans %}You're receiving this email because you requested a password reset for your user account at {{ site_name }}.{% endblocktrans %}
+    {% blocktrans trimmed %}
+        You're receiving this email because you requested a password reset for your user account at {{ site_name }}.
+    {% endblocktrans %}
 {% endblock preheader %}
 
 {% block body %}

--- a/core/templates/email/snippets/image.html
+++ b/core/templates/email/snippets/image.html
@@ -1,6 +1,10 @@
-{# {% include 'hosting/emails/image.hmtl with src= width= height= alt= link= only %} #}
+{# {% include 'hosting/emails/image.html with src= width= height= alt= link= only %} #}
 <tr>
     <td class="padding" align="center">
-        <a href="{{ url }}" target="_blank"><img src="{{ src }}" width="{{ width }}" height="{{ height }}" border="0" alt="{{ alt }}" style="display: block; padding: 0; color: #666666; text-decoration: none; font-family: Helvetica, arial, sans-serif; font-size: 16px;" class="img-max"></a>
+        <a href="{{ url }}" target="_blank">
+            <img src="{{ src }}" width="{{ width }}" height="{{ height }}" alt="{{ alt }}"
+                 style="display: block; padding: 0; color: #666666; text-decoration: none; font-family: Helvetica, arial, sans-serif; font-size: 16px;"
+                 class="img-max" border="0">
+        </a>
     </td>
 </tr>

--- a/core/templates/registration/password_reset_confirm.html
+++ b/core/templates/registration/password_reset_confirm.html
@@ -1,5 +1,5 @@
 {% extends 'core/base_form.html' %}
-{% load i18n bootstrap %}
+{% load i18n bootstrap static %}
 
 {% block form_block_class %} password reset{% endblock %}
 
@@ -40,4 +40,9 @@
             {% trans "New password link" %}
         </a>
     {% endif %}
+{% endblock %}
+
+{% block body %}
+    {{ block.super }}
+    <script src="{% static 'pwstrength/js/zxcvbn.js' %}"></script>
 {% endblock %}

--- a/core/templates/registration/password_reset_confirm.html
+++ b/core/templates/registration/password_reset_confirm.html
@@ -1,6 +1,8 @@
 {% extends 'core/base_form.html' %}
 {% load i18n bootstrap static %}
 
+{% block head_title %}{% trans "Password reset" %}{% endblock %}
+
 {% block form_block_class %} password reset{% endblock %}
 
 {% block form_submit_button %}{% trans "Change my password" %}{% endblock %}

--- a/core/templates/registration/password_reset_done.html
+++ b/core/templates/registration/password_reset_done.html
@@ -1,6 +1,8 @@
 {% extends 'core/base.html' %}
 {% load i18n %}
 
+{% block head_title %}{% trans "Password reset" %}{% endblock %}
+
 {% block page %}
     <h1 class="text-center">{% trans "Password reset" %}</h1>
     <h3 class="text-center">

--- a/core/templates/registration/password_reset_form.html
+++ b/core/templates/registration/password_reset_form.html
@@ -1,6 +1,7 @@
 {% extends 'core/base_form.html' %}
 {% load i18n bootstrap %}
 
+{% block head_title %}{% trans "Password reset" %}{% endblock %}
 
 {% block form_title %}{% trans "Password reset" %}{% endblock %}
 {% block form_tip %}{% trans "Forgotten your password? Enter your email address below, and we'll email instructions for setting a new one." %}{% endblock %}

--- a/core/urls.py
+++ b/core/urls.py
@@ -15,6 +15,9 @@ from .views import (
     mark_email_invalid, mark_email_valid,
     mass_mail, mass_mail_sent,
 )
+from .forms import (
+    SystemPasswordResetRequestForm, SystemPasswordResetForm
+)
 
 
 urlpatterns = [
@@ -27,12 +30,14 @@ urlpatterns = [
     url(_(r'^password/$'), view=password_change, name='password_change'),
     url(_(r'^password/done/$'), view=password_change_done, name='password_change_done'),
     url(_(r'^password/reset/$'), view=password_reset, name='password_reset',
-        kwargs={'html_email_template_name': 'email/password_reset.html',
+        kwargs={'password_reset_form': SystemPasswordResetRequestForm,
+                'html_email_template_name': 'email/password_reset.html',
                 'email_template_name': 'email/password_reset.txt',
                 'subject_template_name': 'email/password_reset_subject.txt'}),
     url(_(r'^password/reset/done/$'), view=password_reset_done, name='password_reset_done'),
     url(_(r'^reset/(?P<uidb64>[0-9A-Za-z_\-]+)/(?P<token>[0-9A-Za-z]{1,13}-[0-9A-Za-z]{1,20})/$'),
-        view=password_reset_confirm, name='password_reset_confirm'),
+        view=password_reset_confirm, name='password_reset_confirm',
+        kwargs={'set_password_form': SystemPasswordResetForm}),
     url(_(r'^reset/done/$'), view=password_reset_complete, name='password_reset_complete'),
 
     url(_(r'^username/$'), username_change, name='username_change'),

--- a/pasportaservo/settings/dev.py
+++ b/pasportaservo/settings/dev.py
@@ -18,6 +18,10 @@ MIDDLEWARE_CLASSES += (
     'debug_toolbar.middleware.DebugToolbarMiddleware',
 )
 
+DEBUG_TOOLBAR_CONFIG = {
+    'JQUERY_URL': '',
+}
+
 # MailDump
 # $ sudo pip install maildump (python 2 only)
 # $ maildump


### PR DESCRIPTION
Povas esti ke la adreso paneis portempe kaj nun denove funkcias. Eblas ke la uzanto tute ne scias ke estis markita INVALID en la datumbazo de PS. Tiaj uzantoj devas daŭre havi la eblecon reagordi la pasvorton (_password reset flow_).

Tirpeto baziĝas sur #82.