### PR TITLE
Privateco Ⅶ (diversaj ŝanĝetoj)

### DIFF
--- a/core/auth.py
+++ b/core/auth.py
@@ -231,8 +231,11 @@ class AuthMixin(AccessMixin):
                                         place=self.get_location(object),
                                         no_obj_context=context_omitted)
         if getattr(self, 'exact_role', None):
-            auth_log.info("exact role allowed: {- %s -} , current role: {- %s -}", self.exact_role, self.role)
-            if self.role == self.exact_role:
+            roles_allowed = self.exact_role if isinstance(self.exact_role, tuple) else (self.exact_role, )
+            auth_log.info(
+                "exact role allowed: {- %s -} , current role: {- %s -}",
+                " or ".join(str(r) for r in roles_allowed), self.role)
+            if self.role in roles_allowed:
                 return object
         else:
             auth_log.info("minimum role allowed: {- %s -} , current role: {- %s -}", self.minimum_role, self.role)

--- a/core/static/sass/_all.scss
+++ b/core/static/sass/_all.scss
@@ -488,18 +488,20 @@ a.contact-details:not(:hover) {
 }
 .list-vertical-align {
     min-height: 3.5em;
-}
-.list-vertical-align .family-member,
-.list-vertical-align .phone-number {
-    margin-top: 0.5em;
-    margin-bottom: 0em;
-}
-.list-vertical-align .member,
-.list-vertical-align .number {
-    font-weight: bold;
-    margin: 0 1em 0 0.5em;
-    & + .conceal-marker {
-        margin-right: 0.6em;
+
+    .family-member,
+    .phone-number,
+    .public-email {
+        margin-top: 0.5em;
+        margin-bottom: 0em;
+    }
+    .member,
+    .number {
+        font-weight: bold;
+        margin: 0 1em 0 0.5em;
+        & + .conceal-marker {
+            margin-right: 0.6em;
+        }
     }
 }
 .family-member .member {

--- a/hosting/templates/hosting/place_detail.html
+++ b/hosting/templates/hosting/place_detail.html
@@ -9,9 +9,13 @@
         {% if place.available %}
             {% trans "A place in" %}
         {% else %}
-            {{ place.owner.name|default:place.owner.INCOGNITO }},
+            {{ place.owner.name|default:place.owner.INCOGNITO }} &ndash;
         {% endif %}
-        {{ place }}
+        {% if user.is_authenticated %}
+            {{ place }}
+        {% else %}
+            {{ place.get_country_display }}
+        {% endif %}
     {% endif %}
 {% endblock %}
 

--- a/hosting/templates/hosting/profile_detail.html
+++ b/hosting/templates/hosting/profile_detail.html
@@ -326,7 +326,7 @@
                     </div>
                 {% else %}
                     {% if not place.visibility.online_public %}
-                        {% expr _("not displayed to visitors") as concealed_title %}
+                        {% expr _("not displayed to other users") as concealed_title %}
                         <span class="conceal-marker fa fa-eye-slash pull-left text-muted" aria-hidden="true"
                               title="{{ concealed_title }}" data-toggle="tooltip"></span>
                         <span class="sr-only">{% trans "Note " context 'Title' %}: {{ concealed_title }}</span>
@@ -384,7 +384,7 @@
                 {% expr "" as concealed_class %}{% expr "" as concealed_title %}
                 {% if not phone.visibility.online_public %}
                     {% expr "concealed" as concealed_class %}
-                    {% expr _("not displayed to visitors") as concealed_title %}
+                    {% expr _("not displayed to other users") as concealed_title %}
                 {% endif %}
                 {% if not phone.visibility.online_public and phone.visibility.online_authed %}
                     {% expr "concealed-partially" as concealed_class %}
@@ -408,5 +408,49 @@
             {% endfor %}
         </ul>
         {% block phone_add_buttons %}{% endblock %}
+
+        <hr />
+
+        {% if profile.email %}
+            <h2 class="owner">{% trans "Public email address" %}</h2>
+            <ul class="list-group">
+                {% expr "" as concealed_class %}{% expr "" as concealed_title %}{% expr "" as concealed_reason %}
+                {% if not profile.email_visibility.online_public and profile.email_visibility.online_authed  %}
+                    {% expr "concealed-partially" as concealed_class %}
+                    {% expr _("displayed to guests and hosts only") as concealed_title %}
+                {% endif %}
+                {% if not profile.email_visibility.online_public and not profile.email_visibility.online_authed or profile.email|is_invalid %}
+                    {% expr "concealed" as concealed_class %}
+                    {% expr _("not displayed to other users") as concealed_title %}
+                    {% if profile.email|is_invalid %}
+                        {% expr _("this email address seems invalid") as concealed_reason %}
+                    {% endif %}
+                {% endif %}
+
+                <li class="list-group-item list-vertical-align {{ concealed_class }}">
+                    {% block email_edit_buttons %}{% endblock %}
+
+                    <p class="public-email text-nowrap">
+                        {{ profile|icon:'email' }}
+                        {% if profile.email|is_invalid %}
+                            <span class="number person-email-address"
+                                  data-toggle="tooltip" title="{{ concealed_reason }}" aria-label="{% trans "Warning " context 'Title' %}: {{ concealed_reason }}">
+                                {{ profile.email|clear_invalid }}
+                                <span class="fa fa-exclamation-triangle text-danger" aria-hidden="true"></span>
+                            </span>
+                        {% else %}
+                            <span class="number person-email-address">
+                                {{ profile.email }}
+                            </span>
+                        {% endif %}
+                        {% if concealed_title %}
+                            <span class="conceal-marker fa fa-eye-slash" aria-hidden="true"
+                                  title="{{ concealed_title }}{% if concealed_reason %} – {{ concealed_reason }}{% endif %}" data-toggle="tooltip"></span>
+                            <span class="sr-only">{% trans "Note " context 'Title' %}: {{ concealed_title }}{% if concealed_reason %} – {{ concealed_reason }}{% endif %}</span>
+                        {% endif %}
+                    </p>
+                </li>
+            </ul>
+        {% endif %}
     {% endif %}
 {% endblock page %}

--- a/hosting/templates/hosting/profile_edit.html
+++ b/hosting/templates/hosting/profile_edit.html
@@ -131,3 +131,14 @@
         <strong>{% trans "Add a phone" %}</strong>
     </a>
 {% endblock %}
+
+{% block email_edit_buttons %}
+    <div class="btn-group pull-right">
+        <a href="{% url 'profile_email_update' profile.pk profile.autoslug %}"
+           class="btn btn-smaller-xxs btn-success"
+           title="{% trans "Update public email" %}">
+            <span class="fa fa-pencil-square-o" aria-hidden="true"></span>
+            <span class="hidden-xs">{% trans "Update" %}</span>
+        </a>
+    </div>
+{% endblock %}

--- a/hosting/templates/hosting/settings.html
+++ b/hosting/templates/hosting/settings.html
@@ -147,7 +147,7 @@
         </section>
     </section>
 
-    {% if view.role == roles.OWNER or view.role == roles.ADMIN %}
+    {% if view.role >= roles.OWNER %}
     <section class="callout callout-warning">
         <h4 id="{% trans "privacy" context "URL" %}">
             {% trans "Privacy" %}

--- a/hosting/views/profiles.py
+++ b/hosting/views/profiles.py
@@ -238,7 +238,8 @@ class ProfileSettingsView(ProfileDetailView):
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
         context['privacy_matrix'] = ProfilePrivacyUpdateView.VisibilityFormSet(
-            profile=self.object, read_only=(self.role > OWNER),
+            profile=self.object,
+            read_only=(self.role > OWNER and self.role < ADMIN),
             prefix=ProfilePrivacyUpdateView.VISIBILITY_FORMSET_PREFIX)
         context['optinouts_form'] = PreferenceOptinsForm(instance=self.object.pref)
         return context
@@ -265,7 +266,7 @@ class ProfileEmailUpdateView(
 
 class ProfilePrivacyUpdateView(AuthMixin, ProfileMixin, generic.View):
     http_method_names = ['post']
-    exact_role = OWNER
+    exact_role = (OWNER, ADMIN)
 
     VisibilityFormSet = modelformset_factory(
         VisibilitySettings,

--- a/locale/eo/LC_MESSAGES/django.po
+++ b/locale/eo/LC_MESSAGES/django.po
@@ -7,7 +7,7 @@ msgstr ""
 "Project-Id-Version: Pasporta Servo pasportaservo\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2017-12-07 22:30+0000\n"
-"POT-Revision-Date: 2019-05-09 16:19+0000\n"
+"POT-Revision-Date: 2019-05-13 06:29+0000\n"
 "Last-Translator: Meir <interDist@users.noreply.github.com>\n"
 "Language-Team: EO <saluton@pasportaservo.org>\n"
 "Language: eo\n"
@@ -1705,14 +1705,20 @@ msgid_plural "I can host during %(max_night)s nights maximum"
 msgstr[0] "Mi povas gastigi dum %(max_night)s nokto maksimume"
 msgstr[1] "Mi povas gastigi dum %(max_night)s noktoj maksimume"
 
-msgid "not displayed to visitors"
-msgstr "nevidebla al vizitantoj"
+msgid "not displayed to other users"
+msgstr "nevidebla al aliaj pasportservanoj"
 
 msgid "Phones"
 msgstr "Telefonoj"
 
 msgid "displayed to guests and hosts only"
 msgstr "videbla nur al gastoj kaj gastigantoj"
+
+msgid "Public email address"
+msgstr "Publika retpoŝta adreso"
+
+msgid "this email address seems invalid"
+msgstr "tiu ĉi retpoŝtadreso ŝajne ne funkcias"
 
 msgid "Update profile"
 msgstr "Redakti profilon"

--- a/locale/eo/LC_MESSAGES/django.po
+++ b/locale/eo/LC_MESSAGES/django.po
@@ -7,7 +7,7 @@ msgstr ""
 "Project-Id-Version: Pasporta Servo pasportaservo\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2017-12-07 22:30+0000\n"
-"POT-Revision-Date: 2019-01-09 16:32+0000\n"
+"POT-Revision-Date: 2019-05-09 16:19+0000\n"
 "Last-Translator: Meir <interDist@users.noreply.github.com>\n"
 "Language-Team: EO <saluton@pasportaservo.org>\n"
 "Language: eo\n"
@@ -162,6 +162,16 @@ msgid ""
 msgstr ""
 "Bedaŭrinde vi ankoraŭ estas tro juna por uzi Pasportan Servon. Atendu ĝis "
 "kiam vi {min_age}-jariĝos!"
+
+msgid "Inbox"
+msgstr "Poŝtkesto"
+
+msgid ""
+"To be able to communicate with other members of the PS community, you need "
+"to create a profile."
+msgstr ""
+"Por havi la eblecon komuniki kun aliaj PS-anoj, vi devas krei kaj agordi "
+"vian profilon."
 
 msgid "site name"
 msgstr "reteja nomo"
@@ -597,6 +607,17 @@ msgstr ""
 
 msgid "Send"
 msgstr "Sendi"
+
+msgid "Profile required"
+msgstr "Profilo estas necesa"
+
+msgid ""
+"In order to use this function of the website, you need to create a profile "
+"first."
+msgstr "Por uzi tiun ĉi parton de la retejo, vi antaŭe devas agordi profilon."
+
+msgid "Create profile"
+msgstr "Krei profilon"
 
 msgctxt "Imperative"
 msgid "Register"

--- a/pasportaservo/urls.py
+++ b/pasportaservo/urls.py
@@ -1,12 +1,13 @@
 from django.conf import settings
 from django.conf.urls import include, url
 from django.contrib import admin
+from django.urls import reverse_lazy
 from django.utils.translation import ugettext_lazy as _
 
 urlpatterns = [
     url('', include('core.urls')),
     url(_(r'^management/'), admin.site.urls),
-    url(_(r'^messages/'), include('postman.urls', namespace='postman', app_name='postman')),
+    url(_(r'^messages/'), include('postman.urls', namespace='postman')),
     url('', include('hosting.urls')),
     url('', include('pages.urls')),
     url('', include('links.urls')),
@@ -21,3 +22,7 @@ if settings.DEBUG:
     urlpatterns += [
         url(r'^__debug__/', include(debug_toolbar.urls)),
     ]
+
+url_index_postman = '/'.join([reverse_lazy('postman:inbox').rstrip('/').rsplit('/', maxsplit=1)[0], ''])
+url_index_maps = reverse_lazy('world_map')
+url_index_debug = '/__debug__/'


### PR DESCRIPTION
Ĉi tiu enkondukas la jenajn ŝanĝojn:

1. la interna komunikilo ne plu uzeblas se uzanto ne agordis profilon.
2. nomo de la urbo kie lokiĝas loĝejo ne estas malkaŝita al anonimaj vizitantoj.
3. la profil-redakta paĝo enhavas sekcion (kun privateco-indikilo) ankaŭ por la publika retpoŝta adreso.
4. administrantoj ekde nun povos redakti la privateco-agordojn de ajna uzanto (homoj ne komputilkapablaj bezonas evidente helpon pri vidigado de siaj kontaktinformoj); 
landaj organizantoj vidi la privateco-agordojn de uzantoj en sia regiono.