### PR TITLE
Aldonoj/flikoj por postman

### DIFF
--- a/core/templates/registration/profile_create.html
+++ b/core/templates/registration/profile_create.html
@@ -1,0 +1,26 @@
+{% extends 'core/base.html' %}
+{% load i18n %}
+
+{% block head_title %}
+    {% trans "Profile required" as default_title %}
+    {{ function_title|default:default_title }}
+{% endblock %}
+
+{% block page %}
+    <h1 class="text-center text-label-warning">
+        <span class="fa-stack" aria-hidden="true">
+            <span class="fa fa-circle fa-stack-2x"></span>
+            <span class="fa fa-hand-stop-o fa-stack-1x fa-inverse"></span>
+        </span>
+        <span class="sr-only">{% trans "Profile required" %}</span>
+    </h1>
+
+    <h3 class="text-center">
+        {% trans "In order to use this function of the website, you need to create a profile first." as default_description %}
+        {{ function_description|default:default_description }}
+    </h3>
+
+    <div class="text-center" style="margin-top: 40px; margin-bottom: 10px;">
+        <a class="btn btn-lg btn-success" href="{% url 'profile_create' %}"><strong>{% trans "Create profile" %}</strong></a>
+    </div>
+{% endblock page %}

--- a/hosting/models.py
+++ b/hosting/models.py
@@ -56,6 +56,7 @@ PRONOUN_CHOICES = (
     ('Ze/He', pgettext_lazy("Personal Pronoun", "ze or he")),
     ('Any', pgettext_lazy("Personal Pronoun", "any")),
 )
+PRONOUN_NEUTRAL_CHOICE = next(p for p in PRONOUN_CHOICES if p[0] == 'They')
 
 MOBILE, HOME, WORK, FAX = 'm', 'h', 'w', 'f'
 PHONE_TYPE_CHOICES = (
@@ -312,6 +313,8 @@ class VisibilitySettingsForPublicEmail(VisibilitySettings):
 class Profile(TrackingModel, TimeStampedModel):
     INCOGNITO = pgettext_lazy("Name", "Anonymous")
     PRONOUN_ANY = PRONOUN_CHOICES[-1][0]
+    PRONOUN_NEUTRAL = PRONOUN_NEUTRAL_CHOICE[0]
+    PRONOUN_NEUTRAL_VALUE = PRONOUN_NEUTRAL_CHOICE[1]
 
     user = models.OneToOneField(
         settings.AUTH_USER_MODEL,

--- a/hosting/templatetags/profile.py
+++ b/hosting/templatetags/profile.py
@@ -91,6 +91,17 @@ def format_pronoun(profile, tag=''):
 
 
 @register.filter
+def get_pronoun(profile):
+    if profile and profile.pronoun:
+        if profile.pronoun == profile.PRONOUN_ANY:
+            return profile.PRONOUN_NEUTRAL_VALUE
+        else:
+            return profile.get_pronoun_parts()[0]
+    else:
+        return Profile.PRONOUN_NEUTRAL_VALUE
+
+
+@register.filter
 def icon(model, field=''):
     obj = model if not field else model._meta.get_field(field)
     return getattr(obj, 'icon', '')

--- a/locale/eo/LC_MESSAGES/django.po
+++ b/locale/eo/LC_MESSAGES/django.po
@@ -7,7 +7,7 @@ msgstr ""
 "Project-Id-Version: Pasporta Servo pasportaservo\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2017-12-07 22:30+0000\n"
-"POT-Revision-Date: 2019-05-13 06:29+0000\n"
+"POT-Revision-Date: 2019-05-31 21:32+0000\n"
 "Last-Translator: Meir <interDist@users.noreply.github.com>\n"
 "Language-Team: EO <saluton@pasportaservo.org>\n"
 "Language: eo\n"
@@ -2320,6 +2320,13 @@ msgstr "Malforviŝi"
 
 msgid "No messages."
 msgstr ""
+
+#, python-format
+msgid "%(name)s might not know about your message."
+msgstr "supozeble %(name)s povas ne ekscii pri via mesaĝo."
+
+msgid "Consider contacting the user by"
+msgstr "Prefere kontaktu la uzanton per"
 
 msgid "recipient"
 msgstr ""

--- a/pasportaservo/__init__.py
+++ b/pasportaservo/__init__.py
@@ -1,0 +1,25 @@
+from django.conf import settings
+
+import postman
+
+
+def patch_postman():
+    from postman.utils import notify_user as original_notify_user
+
+    def patched_notify_user(object, action, site):
+        from postman.utils import notification
+        if not notification:
+            if action == 'rejection':
+                user = object.sender
+            elif action == 'acceptance':
+                user = object.recipient
+            else:
+                user = None
+            if user and user.email.startswith(settings.INVALID_PREFIX):
+                return
+        original_notify_user(object, action, site)
+
+    postman.utils.notify_user = patched_notify_user
+
+
+patch_postman()

--- a/pasportaservo/templates/postman/base_write.html
+++ b/pasportaservo/templates/postman/base_write.html
@@ -1,5 +1,5 @@
 {% extends 'postman/base.html' %}
-{% load i18n static %}
+{% load i18n static expression profile privacy %}
 
 {% block extra_head %}
     {{ block.super }}
@@ -16,6 +16,46 @@
 {% block content %}
     <div id="postman">
         <h1>{% block pm_write_title %}{% endblock %}</h1>
+
+        {% if target_user.email|is_invalid %}
+            <div class="alert alert-danger">
+                <strong>{% trans "Warning " context "Title" %}</strong>&ensp;
+                {% trans "The user's email address seems invalid" %};
+                {% blocktrans with name=target_user.profile|get_pronoun trimmed %}
+                    {{ name }} might not know about your message.
+                {% endblocktrans %}
+
+                {% if target_user.profile.email and not target_user.profile.email|is_invalid %}
+                {% if-visible target_user.profile [email] privileged=view.author_is_authorized %}
+                    {% expr target_user.profile.email as shown_email %}
+                {% endif %}
+                {% endif %}
+                {% if target_public_phones %}
+                    {% expr target_public_phones[0] as shown_phone %}
+                {% endif %}
+                {% if shown_email or shown_phone %}
+                    <br />
+                    {% trans "Consider contacting the user by" %}&nbsp;
+                    {% if shown_email %}
+                        <span class="contact-details text-nowrap">
+                            {% spaceless %}
+                                <span>{{ target_user.profile|icon:'email' }}</span>
+                                <span class="person-email-address adjusted">{{ shown_email }}</span>
+                            {% endspaceless %}
+                        </span>
+                        {% if shown_phone %}
+                            {% trans " or " %}
+                        {% endif %}
+                    {% endif %}
+                    {% if shown_phone %}
+                        <span class="contact-details text-nowrap">
+                            {{ shown_phone.icon }} {{ shown_phone.number.as_international }}
+                        </span>
+                    {% endif %}
+                {% endif %}
+            </div>
+        {% endif %}
+
         <form action="{% if next_url %}?next={{ next_url|urlencode }}{% endif %}" method="post">{% csrf_token %}
             {% block pm_write_recipient %}{% endblock %}
             <div class="form-group">

--- a/pasportaservo/urls.py
+++ b/pasportaservo/urls.py
@@ -4,6 +4,8 @@ from django.contrib import admin
 from django.urls import reverse_lazy
 from django.utils.translation import ugettext_lazy as _
 
+from .views import ExtendedWriteView
+
 urlpatterns = [
     url('', include('core.urls')),
     url(_(r'^management/'), admin.site.urls),
@@ -26,3 +28,7 @@ if settings.DEBUG:
 url_index_postman = '/'.join([reverse_lazy('postman:inbox').rstrip('/').rsplit('/', maxsplit=1)[0], ''])
 url_index_maps = reverse_lazy('world_map')
 url_index_debug = '/__debug__/'
+
+for module in (m for m in urlpatterns if m.app_name == 'postman'):
+    for pattern in (p for p in module.url_patterns if p.name == 'write'):
+        pattern.callback = ExtendedWriteView.as_view()

--- a/pasportaservo/views.py
+++ b/pasportaservo/views.py
@@ -1,4 +1,13 @@
+from django.contrib.auth import get_user_model
+from django.db.models import Q
+from django.utils.functional import SimpleLazyObject, cached_property
 from django.views.defaults import ERROR_403_TEMPLATE_NAME, permission_denied
+
+from postman.views import WriteView
+
+from hosting.models import Phone, Place, Profile
+
+User = get_user_model()
 
 
 def custom_permission_denied_view(request, exception, template_name=ERROR_403_TEMPLATE_NAME):
@@ -17,3 +26,44 @@ def custom_permission_denied_view(request, exception, template_name=ERROR_403_TE
     except IndexError:
         pass
     return response
+
+
+class ExtendedWriteView(WriteView):
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        recipients = context['form'].initial.get('recipients')
+        if recipients:
+            to = recipients.split(', ')[0]
+            self.to_user = User.objects.get(username=to)
+            context['target_user'] = self.to_user
+            context['target_public_phones'] = SimpleLazyObject(lambda: self.target_user_public_phones)
+        else:
+            context['target_user'] = None
+        return context
+
+    @cached_property
+    def author_is_authorized(self):
+        try:
+            auth_users = Place.objects.filter(owner=self.to_user.profile).values_list('authorized_users', flat=True)
+        except (AttributeError, Profile.DoesNotExist):
+            return False
+        is_authorized = (self.request.user.pk in auth_users)
+        return is_authorized
+
+    @cached_property
+    def target_user_public_phones(self):
+        try:
+            if self.author_is_authorized:
+                by_visibility = Q(visibility__visible_online_authed=True)
+            else:
+                by_visibility = Q(visibility__visible_online_public=True)
+            phones = (
+                Phone.objects
+                .filter(profile=self.to_user.profile)
+                .filter(by_visibility)
+                .select_related(None)
+                .only('number', 'type', 'country')
+            )
+        except (AttributeError, Profile.DoesNotExist):
+            phones = None
+        return phones

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -6,10 +6,11 @@ from django.contrib.gis.geos import Point
 from django_countries.data import COUNTRIES
 from django_countries.fields import Country
 from factory import (
-    DjangoModelFactory, Faker, LazyAttribute, PostGenerationMethodCall,
-    RelatedFactory, SubFactory, lazy_attribute,
+    DjangoModelFactory, Faker, LazyAttribute, LazyAttributeSequence,
+    PostGenerationMethodCall, RelatedFactory, SubFactory, lazy_attribute,
 )
 from phonenumber_field.phonenumber import PhoneNumber
+from slugify import slugify
 
 from hosting.models import MR, MRS, PHONE_TYPE_CHOICES, PRONOUN_CHOICES
 from maps import COUNTRIES_WITH_MANDATORY_REGION, SRID
@@ -127,3 +128,14 @@ class PhoneFactory(DjangoModelFactory):
     country = LazyAttribute(lambda obj: Country(choice(list(COUNTRIES))))
     comments = Faker('text', max_nb_chars=20)
     type = Faker('random_element', elements=[ch[0] for ch in PHONE_TYPE_CHOICES])
+
+
+class ConditionFactory(DjangoModelFactory):
+    class Meta:
+        model = 'hosting.Condition'
+        exclude = ('word',)
+
+    word = Faker('word')
+    name = LazyAttribute(lambda obj: '{} {}.'.format(obj.word.title(), obj.word[::-1]))
+    abbr = LazyAttributeSequence(lambda obj, n: 'p/{}/{}'.format(obj.word[:6], n))
+    slug = LazyAttribute(lambda obj: slugify(obj.abbr, to_lower=True, separator='-'))

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -1,5 +1,5 @@
 # https://faker.readthedocs.io/en/latest/providers/faker.providers.person.html
-from random import choice, random, uniform as uniform_random
+from random import choice, randint, random, uniform as uniform_random
 
 from django.contrib.gis.geos import Point
 
@@ -9,8 +9,9 @@ from factory import (
     DjangoModelFactory, Faker, LazyAttribute, PostGenerationMethodCall,
     RelatedFactory, SubFactory, lazy_attribute,
 )
+from phonenumber_field.phonenumber import PhoneNumber
 
-from hosting.models import MR, MRS, PRONOUN_CHOICES
+from hosting.models import MR, MRS, PHONE_TYPE_CHOICES, PRONOUN_CHOICES
 from maps import COUNTRIES_WITH_MANDATORY_REGION, SRID
 from maps.data import COUNTRIES_GEO
 
@@ -108,3 +109,21 @@ class PlaceFactory(DjangoModelFactory):
     description = Faker('paragraph', nb_sentences=4)
     short_description = Faker('text', max_nb_chars=140)
     in_book = False
+
+
+class PhoneFactory(DjangoModelFactory):
+    class Meta:
+        model = 'hosting.Phone'
+        django_get_or_create = ('profile',)
+
+    profile = SubFactory('tests.factories.ProfileFactory')
+    @lazy_attribute
+    def number(self):
+        # the Faker's phone-number provider is a mess.
+        phone = PhoneNumber()
+        while not phone.is_valid():
+            phone = PhoneNumber(country_code=randint(1, 999), national_number=randint(10000000, 9999999990))
+        return phone
+    country = LazyAttribute(lambda obj: Country(choice(list(COUNTRIES))))
+    comments = Faker('text', max_nb_chars=20)
+    type = Faker('random_element', elements=[ch[0] for ch in PHONE_TYPE_CHOICES])

--- a/tests/models/test_condition_model.py
+++ b/tests/models/test_condition_model.py
@@ -1,0 +1,14 @@
+from django_webtest import WebTest
+
+from ..factories import ConditionFactory
+
+
+class ConditionModelTests(WebTest):
+    def test_field_max_lengths(self):
+        cond = ConditionFactory()
+        self.assertEquals(cond._meta.get_field('name').max_length, 255)
+        self.assertEquals(cond._meta.get_field('abbr').max_length, 20)
+
+    def test_str(self):
+        cond = ConditionFactory()
+        self.assertEquals(str(cond), cond.name)

--- a/tests/models/test_phone_model.py
+++ b/tests/models/test_phone_model.py
@@ -1,0 +1,18 @@
+from django_webtest import WebTest
+
+from ..factories import PhoneFactory
+
+
+class PhoneModelTests(WebTest):
+    def test_field_max_lengths(self):
+        phone = PhoneFactory()
+        self.assertEquals(phone._meta.get_field('comments').max_length, 255)
+        self.assertEquals(phone._meta.get_field('type').max_length, 3)
+
+    def test_owner(self):
+        phone = PhoneFactory()
+        self.assertIs(phone.owner, phone.profile)
+
+    def test_str(self):
+        phone = PhoneFactory()
+        self.assertEquals(str(phone), phone.number.as_international)


### PR DESCRIPTION
Du ŝanĝoj estas enkondukitaj en la manieron _postman_ funkcias sur la retejo:
* En la mesaĝverka ŝablono aperas indikilo se la retpoŝta adreso de la kontaktato ne funkcias (INVALID_). Kiam ekzistas aliaj publikaj kontakto-manieroj, ili estas indikitaj.
   * por ebligi la montradon de tiuj ĉi informoj, la Vido _`postman.views.WriteView`_ devis esti etendita kaj dinamike anstataŭigita en la pakaĵo.
* La sendo de la mesaĝo ne kaŭzas sendon de sciiga retpoŝta mesaĝo se la adreso de la kontaktato ne funkcias. La adreso ĉiukaze ne validas (enhavas INVALID_) kaj la persono neniam ricevus la sciigon.
   * por ebligi tion, la interna funkcio _`postman.utils.notify_user`_ devis estis anstataŭigita, ĉar _postman_ ne subtenas tajloradon de retpoŝtaj sciigoj (vd. https://bitbucket.org/psam/django-postman/issues/114/).