### PR TITLE
Aldono de kaj korektoj de funkcioj por landaj organizantoj

### DIFF
--- a/core/static/js/ajax.js
+++ b/core/static/js/ajax.js
@@ -192,7 +192,7 @@ $(document).ready(function() {
             }
             for (var field in response.err) {
                 $op_errors.append($(document.createElement('li')).text(
-                    field + ": " + response.err[field]
+                    field + ": " + response.err[field].map(function(e) { return e.replace(/[.!]+$/g, "") }).join("; ")
                 ));
             }
             $op_notify.modal();

--- a/core/static/js/ajax.js
+++ b/core/static/js/ajax.js
@@ -211,7 +211,9 @@ $(document).ready(function() {
             }
             var $marker = $this.siblings($this.data('process-elem') || "undefined");
             var buttonWidth = $this.width();
-            $this.prop('disabled', true);
+            $this.prop('disabled', true)
+                 .removeData('hover-text').removeAttr('data-hover-text')
+                 .removeData('hover-class').removeAttr('data-hover-class');
             if ($marker.length) {
                 $this.html($marker).width(buttonWidth);
                 $marker.show().delay(Math.random()*1500 + 1000)

--- a/core/static/js/scripts.js
+++ b/core/static/js/scripts.js
@@ -242,7 +242,7 @@ function enableTooltips() {
 
 // Host preferences popover
 function displayAnchorsNotification() {
-    var blockSmallDescription = $('.description-small');
+    var blockSmallDescription = $('.description-smallvp');
     $('html, body').animate({ scrollTop: blockSmallDescription.offset().top - 10 }, 500);
 
     var origin = $('.anchor-notify');

--- a/core/static/js/scripts.js
+++ b/core/static/js/scripts.js
@@ -21,7 +21,7 @@ $(document).ready(function() {
     // Button hover
     $('.btn').hover(function() {
         var $this = $(this);
-        $this.data('original-text', $this.text());
+        $this.data('original-text', $this.html());
         if ($this.data('hover-text')) {
             var preserveWidth = $this.width();
             $this.text($this.data('hover-text')).width(preserveWidth);
@@ -32,7 +32,7 @@ $(document).ready(function() {
     }, function() {
         var $this = $(this);
         if ($this.data('hover-text') && $this.data('original-text')) {
-            $this.text($this.data('original-text')).width("auto");
+            $this.html($this.data('original-text')).width("auto");
         }
         if ($this.data('hover-class')) {
             $this.removeClass($this.data('hover-class'));

--- a/core/static/sass/_all.scss
+++ b/core/static/sass/_all.scss
@@ -692,6 +692,7 @@ html.js-enabled #tasks-header[data-toggle="collapse"] {
         margin-left: 20px;
     }
     .control-buttons .timestamp {
+        white-space: pre;
         margin-bottom: 0px;
         margin-right: 1px;
         &:first-of-type {

--- a/core/static/sass/_all.scss
+++ b/core/static/sass/_all.scss
@@ -353,7 +353,16 @@ header:not(.home) #subtitle,
 .place-detail .place-blocking {
     clear: right;
 }
-.description-small {
+.place-detail .timestamp {
+    font-size: 80%;
+    white-space: pre;
+}
+.description-largevp {
+    p:first-child {
+        margin-top: 10px;
+    }
+}
+.description-smallvp {
     margin-top: 1em;
     margin-bottom: 1em;
 }
@@ -488,6 +497,14 @@ p.tip {
     .mfp-wrap {
         position: fixed !important;
         top: 0px !important;
+    }
+}
+.profile-detail .timestamp {
+    font-size: 80%;
+    white-space: pre;
+    &.timestamp-edit {
+        position: relative;
+        top: 1.15ex;
     }
 }
 .contact-details:not(a) {

--- a/core/templatetags/variable.py
+++ b/core/templatetags/variable.py
@@ -1,6 +1,7 @@
 import re
 
 from django import template
+from django.utils.safestring import mark_safe
 
 register = template.Library()
 
@@ -16,7 +17,7 @@ class VarNode(template.Node):
     def render(self, context):
         result = self.nodelist.render(context)
         if self.trim_contents:
-            result = result.strip()
+            result = mark_safe(result.strip())
         if self.var_is_global:
             context.dicts[0][self.var_name] = result
         else:

--- a/hosting/admin/admin.py
+++ b/hosting/admin/admin.py
@@ -175,7 +175,7 @@ class CustomGroupAdmin(GroupAdmin):
                     is_deleted = is_deleted or u.profile.deleted_on
                 indicator = '<span style="color:#dd4646">&#x2718;!</span>' if is_deleted else ''
                 yield " ".join([indicator, account_link, profile_link])
-        return format_html(", ".join(get_formatted_list()))
+        return format_html(", ".join(get_formatted_list())) if len(obj.name) == 2 else "-"
     supervisors.short_description = _("Supervisors")
 
     class CountryGroup(Group):
@@ -398,7 +398,9 @@ class ProfileAdmin(TrackingModelAdmin, ShowDeletedMixin, admin.ModelAdmin):
     checked_by__name.admin_order_field = 'checked_by__username'
 
     def supervisor(self, obj):
-        country_list = CustomGroupAdmin.CountryGroup.objects.filter(user__pk=obj.user_id if obj.user_id else -1)
+        country_list = CustomGroupAdmin.CountryGroup.objects.filter(
+            name__regex=r'^[A-Z]{2}$',
+            user__pk=obj.user_id if obj.user_id else -1)
         if country_list:
             return format_html(',&nbsp; '.join(map(str, country_list)))
         else:

--- a/hosting/fields.py
+++ b/hosting/fields.py
@@ -151,9 +151,6 @@ class ForeigKeyWithSuggestions(models.ForeignKey):
             )
         return errors
 
-    def get_attname(self):
-        return '{}_value'.format(self.name)
-
     class LenientForwardDescriptor(ForwardManyToOneDescriptor):
         def get_object(self, model_instance):
             try:

--- a/hosting/migrations/0049_profile_gender_pronoun.py
+++ b/hosting/migrations/0049_profile_gender_pronoun.py
@@ -14,10 +14,11 @@ class Migration(migrations.Migration):
 
     operations = [
         # Help text for users to better understand the form field
+        # Explicit db_column to avoid losing data due to a (non-versionable) change of ForeigKeyWithSuggestions' attname
         migrations.AlterField(
             model_name='profile',
             name='gender',
-            field=hosting.fields.ForeigKeyWithSuggestions(blank=True, choices='hosting.Gender', help_text='Type your preference or select one from the suggestions.', to_field='name', verbose_name='gender'),
+            field=hosting.fields.ForeigKeyWithSuggestions(blank=True, choices='hosting.Gender', db_column='gender_value', help_text='Type your preference or select one from the suggestions.', to_field='name', verbose_name='gender'),
         ),
         # Additional and more inclusive pronouns
         migrations.AlterField(

--- a/hosting/models.py
+++ b/hosting/models.py
@@ -225,6 +225,11 @@ class VisibilitySettings(models.Model):
         """Can this data appear in the printed edition?"""
         return True
 
+    @property
+    def concealed(self):
+        """Can this data be seen by anyone apart from owner and supervisors?"""
+        return not any([self.visible_online_public, self.visible_online_authed, self.visible_in_book])
+
     _PREFIX = 'visible_'
 
     @classmethod

--- a/hosting/models.py
+++ b/hosting/models.py
@@ -351,6 +351,7 @@ class Profile(TrackingModel, TimeStampedModel):
         _("gender"),
         blank=True,
         choices='hosting.Gender', to_field='name',
+        db_column='gender_value',
         help_text=_("Type your preference or select one from the suggestions."))
     pronoun = models.CharField(
         _("personal pronoun"),

--- a/hosting/templates/hosting/place_check_detail.html
+++ b/hosting/templates/hosting/place_check_detail.html
@@ -1,0 +1,60 @@
+{% extends 'core/base.html' %}
+{% load i18n %}
+
+{% block head_title %}
+    {% trans "Hosting place verification" %}:
+    {{ place.owner.name|default:place.owner.INCOGNITO }}, {{ place.get_locality_display }}
+{% endblock %}
+
+{% block safe_page_title %}
+    {% if True %}
+            return document.title.replace('{{ place.get_locality_display|escapejs }}', 'XXXXXX (XXXXXX)');
+    {% endif %}
+{% endblock %}
+
+{% block page %}
+    <p class="text-center lead">{% trans "There is a problem with this host's data…" %}</p>
+    <div class="row">
+        <div class="col-xs-12 col-md-6 col-md-offset-3">
+            <dl class="list-group">
+                {% if result.err__all__ %}
+                    <dt class="list-group-item list-group-item-warning">{% trans "General" context "Adverb" %}</dt>
+                    <dd class="list-group-item">
+                        {% for err in result.err__all__ %}
+                            <p>{{ err }}</p>
+                        {% endfor %}
+                    </dd>
+                {% endif %}
+                {% for field_name, field_errors in result.err.items %}
+                    <dt class="list-group-item list-group-item-warning">{{ field_name }}</dt>
+                    <dd class="list-group-item">
+                        {% for err in field_errors %}
+                            <p>{{ err }}</p>
+                        {% endfor %}
+                    </dd>
+                {% endfor %}
+            </dl>
+            <div class="btn-group btn-vert-space pull-right">
+                <a href="{% url 'profile_update' place.owner.pk place.owner.autoslug %}?next={{ request.GET.next|urlencode:"" }}"
+                   class="btn btn-success" tabindex="2">
+                    <span class="hidden-xxs" aria-hidden="true">
+                        <span class="fa fa-user"></span>&nbsp;<span class="fa fa-pencil"></span>&nbsp;
+                    </span>
+                    {% trans "Update profile" %}
+                </a>
+                <a href="{% url 'place_update' place.pk %}?next={{ request.GET.next|urlencode:"" }}"
+                   class="btn btn-success" tabindex="2">
+                    <span class="hidden-xxs" aria-hidden="true">
+                        <span class="fa fa-home"></span>&nbsp;<span class="fa fa-pencil"></span>&nbsp;
+                    </span>
+                    {% blocktrans %}Update {{ kin }}place{% endblocktrans %}
+                </a>
+            </div>
+            <a href="{{ request.GET.next|default:"javascript:history.go(-1)" }}"
+               class="btn btn-default btn-vert-space" tabindex="1">
+                <span class="fa fa-arrow-left" aria-hidden="true"></span>&nbsp;
+                {% trans "Back to previous page" %}
+            </a>
+        </div>
+    </div>
+{% endblock page %}

--- a/hosting/templates/hosting/place_detail.html
+++ b/hosting/templates/hosting/place_detail.html
@@ -1,6 +1,6 @@
 {% extends 'core/base.html' %}
 {% load i18n l10n static geojson_tags %}
-{% load profile privacy expression utils %}
+{% load profile privacy expression variable utils %}
 
 {% block head_title %}
     {% if view.role == roles.OWNER %}
@@ -223,6 +223,28 @@
                             </p>
                         {% endif %}
                         {% endif %}
+
+                        {% if view.role >= roles.SUPERVISOR %}
+                            <p class="col-xs-12 staff">
+                            {# INFORMATION FOR SUPERVISORS #}
+                                {% spaceless %}
+                                    {% asvar last_editor trimmed %}
+                                        {% if place.checked %}
+                                            {% trans "by a supervisor" %}
+                                        {% else %}
+                                            {% trans "owner" %}
+                                        {% endif %}
+                                    {% endasvar %}
+                                    <span class="timestamp timestamp-edit text-muted"
+                                          data-title="{% trans "last modification" %}:<br />{{ place.modified }}<br />({{ last_editor }})"
+                                          data-toggle="tooltip" data-placement="top" data-html="true">
+                                        <small class="fa fa-fw fa-pencil-square-o" aria-hidden="true"></small>
+                                        <span class="sr-only">{% trans "last modification" %}</span>
+                                        <small><samp> {{ place.modified|date:"Y-m-d H:i" }} UTC</samp></small>
+                                    </span>
+                                {% endspaceless %}
+                            </p>
+                        {% endif %}
                     </div>
                 </div>
             {# END OF OWNER'S DETAILS #}
@@ -231,7 +253,7 @@
             <div class="row">
             {# DETAILS AND CONDITIONS OF THE PLACE ON LARGE SCREENS - ACCESSIBLE ONLY TO AUTHENTICATED USERS #}
             {% if user.is_authenticated %}
-                <div class="col-md-12 hidden-xs hidden-sm">
+                <div class="col-md-12 hidden-xs hidden-sm description-largevp">
                     {% list place.description place.contact_before place.max_guest place.max_night as accommodation_details %}
                     {% if accommodation_details|are_any %}
                         <h3>{% trans "Description" %}</h3>
@@ -324,7 +346,7 @@
         </div>
 
         {% if user.is_authenticated %}
-            <div class="col-xs-12 hidden-md hidden-lg description-small">
+            <div class="col-xs-12 hidden-md hidden-lg description-smallvp">
             {# DETAILS AND CONDITIONS OF THE PLACE ON SMALL SCREENS - ACCESSIBLE ONLY TO AUTHENTICATED USERS #}
                 <a id="status-anchors_notification" class="col-xs-12 anchor-notify" data-placement="bottom"
                    data-content="{% include './snippets/place_owner_anchors.html' %}"></a>

--- a/hosting/templates/hosting/place_list_supervisor.html
+++ b/hosting/templates/hosting/place_list_supervisor.html
@@ -254,7 +254,8 @@
                                             {% if phone_dimmed_reason %}style="opacity: 0.55"{% endif %}>
                                             {{ phone.comments }}
                                             {% if phone.comments|is_esperanto_surrogate %}
-                                                <span class="fa fa-exclamation-triangle text-warning" data-toggle="tooltip"
+                                                <span class="fa fa-exclamation-triangle text-warning"
+                                                      data-toggle="tooltip" data-container="#p-{{ place.pk }} address"
                                                       title="{% trans "Esperanto letters?" %}"
                                                       aria-label="{% trans "Warning " context 'Title' %}: {% trans "Esperanto letters?" %}"></span>
                                             {% endif %}

--- a/hosting/templates/hosting/place_list_supervisor.html
+++ b/hosting/templates/hosting/place_list_supervisor.html
@@ -226,15 +226,32 @@
                             {% endwith %}
                         </div>
                         <div>
+                            {# TODO: Phones are re-fetched even though they are in a prefetch... #}
                             {% for phone in place.profile.phones.all %}
                                 {% if not phone.deleted %}
                                     <small class="phone-number">
-
-                                        <b class="number">
+                                        {% asvar phone_dimmed_reason trimmed %}
+                                            {% if view.in_book_status is True and not phone.visibility.in_book %}
+                                                {% trans "not printed in the book" %}
+                                            {% endif %}
+                                            {% if view.in_book_status is False and not phone.visibility.online_public and not phone.visibility.online_authed %}
+                                                {% trans "not displayed to other users" %}
+                                            {% endif %}
+                                            {% if view.in_book_status is None and phone.visibility.concealed %}
+                                                {% trans "The owner set it as not visible to other users" %}
+                                            {% endif %}
+                                        {% endasvar %}
+                                        {% if phone_dimmed_reason %}
+                                            <span class="sr-only">{% trans "Note " context 'Title' %}: {{ phone_dimmed_reason }}"</span>
+                                        {% endif %}
+                                        <b class="number{% if phone_dimmed_reason %} text-muted{% endif %}"
+                                           data-toggle="tooltip" data-placement="top"
+                                           title="{{ phone_dimmed_reason }}">
                                             {{ phone.icon }}
                                             {{ phone.number.as_international }}
                                         </b>
-                                        <em class="comment{% if phone.comments|is_esperanto_surrogate %} text-surrogate text-warning{% endif %}">
+                                        <em class="comment{% if phone.comments|is_esperanto_surrogate %} text-surrogate text-warning{% endif %}"
+                                            {% if phone_dimmed_reason %}style="opacity: 0.55"{% endif %}>
                                             {{ phone.comments }}
                                             {% if phone.comments|is_esperanto_surrogate %}
                                                 <span class="fa fa-exclamation-triangle text-warning" data-toggle="tooltip"

--- a/hosting/templates/hosting/place_list_supervisor.html
+++ b/hosting/templates/hosting/place_list_supervisor.html
@@ -164,16 +164,22 @@
                             </div>
                         </div>
 
-                        <p class="timestamp text-right text-muted" title="{% trans "last login" %}<br />{{ place.owner.user.last_login }}"
+                        {% spaceless %}
+                        <p class="timestamp text-right text-muted"
+                           title="{% trans "last login" %}<br />{{ place.owner.user.last_login|default:_("never") }}"
                            data-toggle="tooltip" data-html="true" data-placement="bottom">
                             <small class="fa fa-sign-in" aria-hidden="true" style="position: relative; left: -2px"></small>
-                            <small><samp>{{ place.owner.user.last_login|date:"Y-m-d H:i" }} UTC</samp></small>
+                            <small><samp> {{ place.owner.user.last_login|date:"Y-m-d H:i"|default:"—"|stringformat:"-16s" }} UTC</samp></small>
                         </p>
-                        <p class="timestamp text-right text-muted" title="{% trans "last modification" %}<br />{{ place.modified }}"
+                        {% endspaceless %}
+                        {% spaceless %}
+                        <p class="timestamp text-right text-muted"
+                           title="{% trans "last modification" %}<br />{{ place.modified|default:_("never") }}"
                            data-toggle="tooltip" data-html="true" data-placement="bottom">
                             <small class="fa fa-pencil-square-o" aria-hidden="true"></small>
-                            <small><samp>{{ place.modified|date:"Y-m-d H:i" }} UTC</samp></small>
+                            <small><samp> {{ place.modified|date:"Y-m-d H:i"|default:"—"|stringformat:"-16s" }} UTC</samp></small>
                         </p>
+                        {% endspaceless %}
                     {# END OF CONTROL BUTTONS #}
                     </div>
 

--- a/hosting/templates/hosting/place_list_supervisor.html
+++ b/hosting/templates/hosting/place_list_supervisor.html
@@ -187,6 +187,11 @@
                                 {% endif %}
                             </h4>
                         </a>
+                        <a href="{% url 'profile_update' place.profile.pk place.profile.autoslug %}?next={{ current_page_position|urlencode:"" }}"
+                           class="btn btn-default btn-sm btn-vert-space">
+                            {% trans "Update profile" %}
+                        </a>
+
                         <div class="address">
                             {{ place.address }}<br />
                             {{ place.postcode}} <span class="fa fa-dot-circle-o" aria-hidden="true"></span> <strong>{{ place.city }}</strong><br />
@@ -224,8 +229,11 @@
                             {% for phone in place.profile.phones.all %}
                                 {% if not phone.deleted %}
                                     <small class="phone-number">
-                                        {{ phone.icon }}
-                                        <b class="number">{{ phone.number.as_international }}</b>
+
+                                        <b class="number">
+                                            {{ phone.icon }}
+                                            {{ phone.number.as_international }}
+                                        </b>
                                         <em class="comment{% if phone.comments|is_esperanto_surrogate %} text-surrogate text-warning{% endif %}">
                                             {{ phone.comments }}
                                             {% if phone.comments|is_esperanto_surrogate %}
@@ -234,6 +242,14 @@
                                                       aria-label="{% trans "Warning " context 'Title' %}: {% trans "Esperanto letters?" %}"></span>
                                             {% endif %}
                                         </em>
+                                        {% spaceless %}
+                                        <a href="{% url 'phone_update' place.profile.pk phone.pk %}?next={{ current_page_position|urlencode:"" }}"
+                                           class="action-edit-inline text-label-success"
+                                           title="{% trans "Update a phone number" %}" data-toggle="tooltip">
+                                            <span class="fa fa-pencil-square-o" aria-hidden="true"></span>
+                                            <span class="sr-only">{% trans "Update a phone number" %}</span>
+                                        </a>
+                                        {% endspaceless %}
                                     </small>
                                 {% endif %}
                             {% endfor %}

--- a/hosting/templates/hosting/place_list_supervisor.html
+++ b/hosting/templates/hosting/place_list_supervisor.html
@@ -138,9 +138,11 @@
                                 {% if place.checked %}
                                     {% include './snippets/checked.html' with object=place button=True button_id=id_check_status %}
                                 {% else %}
-                                    <form action="{% url 'place_check' place.pk %}" method="POST" class="unwrap-after-success">
+                                    <form action="{% url 'place_check' place.pk %}?next={{ current_page_position|urlencode:"" }}"
+                                          method="POST"
+                                          class="unwrap-after-success">
                                         {% csrf_token %}
-                                        <button type="button" id="{{ id_check_status }}" class="btn btn-warning ajax"
+                                        <button type="submit" id="{{ id_check_status }}" class="btn btn-warning ajax"
                                                 aria-live="assertive" aria-atomic="true"
                                                 data-csrf="{{ csrf_token }}"
                                                 data-hover-text="{% trans "Check?" %}"
@@ -151,8 +153,9 @@
                                                 data-failure-message="check-place-check-errors"
                                                 autocomplete="off">
                                             {% trans "Not checked" %}
+                                            <span class="sr-only">({% trans "Check?" %})</span>
                                         </button>
-                                        <span class="fa fa-clock-o fa-spin process-icon" style="display: none" aria-label="{% trans "working..." %}">
+                                        <span class="fa fa-clock-o fa-spin process-icon" style="display: none" aria-label="{% trans "working..." %}"></span>
                                     </form>
                                 {% endif %}
                             </div>

--- a/hosting/templates/hosting/profile_detail.html
+++ b/hosting/templates/hosting/profile_detail.html
@@ -170,11 +170,35 @@
                                title="{% trans "invalid email" %}" data-toggle="tooltip"></small>
                     {% endif %}
                 </h4>
+                <h4>
+                    <small>{% trans "last login"|capfirst %}</small>
+                    <br class="visible-xxs-inline" />
+                    <span class="">{{ profile.user.last_login|date:"DATE_FORMAT"|default:_("never") }}</span>
+                </h4>
             </div>
         {% endif %}
     </div>
 
     <hr />
+
+    {% if view.role >= roles.SUPERVISOR %}
+        {% spaceless %}
+            {% asvar last_editor trimmed %}
+                {% if profile.checked %}
+                    {% trans "by a supervisor" %}
+                {% else %}
+                    {% trans "owner" %}
+                {% endif %}
+            {% endasvar %}
+            <span class="timestamp timestamp-edit pull-right text-muted"
+                  data-title="{% trans "last modification" %}:<br />{{ profile.modified }}<br />({{ last_editor }})"
+                  data-toggle="tooltip" data-placement="top" data-html="true">
+                <small class="fa fa-pencil-square-o" aria-hidden="true"></small>
+                <span class="sr-only">{% trans "last modification" %}</span>
+                <small><samp> {{ profile.modified|date:"Y-m-d H:i" }} UTC</samp></small>
+            </span>
+        {% endspaceless %}
+    {% endif %}
 
     <h2 class="owner">{% trans "About me" %}</h2>
     {{ profile.description|linebreaks }}

--- a/hosting/templatetags/profile.py
+++ b/hosting/templatetags/profile.py
@@ -144,4 +144,5 @@ def is_esperanto_surrogate(value):
 
 
 re_esperanto = re.compile(r'cx|gx|hx|jx|sx|ux|ch|gh|hh|jh|sh|'
-                          r'c\^|g\^|h\^|j\^|s\^|u\^|u~|\^c|\^g|\^h|\^j|\^s|\^u|~u')
+                          r'c\^|g\^|h\^|j\^|s\^|u\^|u~|\^c|\^g|\^h|\^j|\^s|\^u|~u',
+                          re.IGNORECASE)

--- a/hosting/views/verification.py
+++ b/hosting/views/verification.py
@@ -52,7 +52,7 @@ class PlaceCheckView(AuthMixin, PlaceMixin, generic.View):
     the requirements from hosts and guests.
     """
     http_method_names = ['post']
-    template_name = '200.html'
+    template_names = {True: '200.html', False: 'hosting/place_check_detail.html'}
     minimum_role = SUPERVISOR
 
     @vary_on_headers('HTTP_X_REQUESTED_WITH')
@@ -87,5 +87,8 @@ class PlaceCheckView(AuthMixin, PlaceMixin, generic.View):
         if request.is_ajax():
             return JsonResponse(viewresponse)
         else:
-            # Not implemented; only AJAX requests are expected.
-            return TemplateResponse(request, self.template_name)
+            return TemplateResponse(
+                request,
+                self.template_names[data_correct],
+                context={'view': self, 'place': place, 'result': viewresponse}
+            )

--- a/locale/eo/LC_MESSAGES/django.po
+++ b/locale/eo/LC_MESSAGES/django.po
@@ -1569,6 +1569,12 @@ msgstr "Esperantaj literoj?"
 msgid "Description too long."
 msgstr "Priskribo tro longa."
 
+msgid "not printed in the book"
+msgstr "ne aperas en la libreto"
+
+msgid "not displayed to other users"
+msgstr "nevidebla al aliaj pasportservanoj"
+
 msgid "Mark invalid"
 msgstr "Marki kiel nefunkcianta"
 
@@ -1724,9 +1730,6 @@ msgid "I can host during %(max_night)s night maximum"
 msgid_plural "I can host during %(max_night)s nights maximum"
 msgstr[0] "Mi povas gastigi dum %(max_night)s nokto maksimume"
 msgstr[1] "Mi povas gastigi dum %(max_night)s noktoj maksimume"
-
-msgid "not displayed to other users"
-msgstr "nevidebla al aliaj pasportservanoj"
 
 msgid "Phones"
 msgstr "Telefonoj"

--- a/locale/eo/LC_MESSAGES/django.po
+++ b/locale/eo/LC_MESSAGES/django.po
@@ -1390,6 +1390,12 @@ msgstr "Indiki maldisponeblon"
 msgid "unavailable"
 msgstr "maldisponebla"
 
+msgid "by a supervisor"
+msgstr "fare de landa organizanto"
+
+msgid "last modification"
+msgstr "lasta redakto"
+
 msgid "Description"
 msgstr "Priskribo"
 
@@ -1558,9 +1564,6 @@ msgstr "lasta ensaluto"
 
 msgid "never"
 msgstr "neniam"
-
-msgid "last modification"
-msgstr "lasta redakto"
 
 #, python-format
 msgid "%(age)s y.o."

--- a/locale/eo/LC_MESSAGES/django.po
+++ b/locale/eo/LC_MESSAGES/django.po
@@ -1556,6 +1556,9 @@ msgstr "Nekontrolita"
 msgid "last login"
 msgstr "lasta ensaluto"
 
+msgid "never"
+msgstr "neniam"
+
 msgid "last modification"
 msgstr "lasta redakto"
 

--- a/locale/eo/LC_MESSAGES/django.po
+++ b/locale/eo/LC_MESSAGES/django.po
@@ -1323,6 +1323,13 @@ msgstr "Nuligita profilo"
 msgid "Remove user"
 msgstr "Forigi uzanton"
 
+msgid "Hosting place verification"
+msgstr "Kontrolo de loĝejo"
+
+msgctxt "Adverb"
+msgid "General"
+msgstr "Ĝenerale"
+
 msgid "my "
 msgstr "mian "
 

--- a/tests/templatetags/test_expression_tag.py
+++ b/tests/templatetags/test_expression_tag.py
@@ -2,10 +2,12 @@ import logging
 import string
 
 from django.template import Context, Template, TemplateSyntaxError
+from django.test import tag
 
 from django_webtest import WebTest
 
 
+@tag('templatetags')
 class ExpressionTagTests(WebTest):
     _sentinel = {'T': 'F', 'r': 'R', 'u': 'A', 't': 'U', 'h': 'D'}
 

--- a/tests/templatetags/test_misc_tags.py
+++ b/tests/templatetags/test_misc_tags.py
@@ -2,11 +2,13 @@ import string
 from collections import namedtuple
 
 from django.template import Context, Template
+from django.test import tag
 
 from django_webtest import WebTest
 from factory import Faker
 
 
+@tag('templatetags')
 class RandomIdentifierTagTests(WebTest):
     template_string = string.Template("{% load random_identifier from utils %}{% random_identifier $LENGTH %}")
     re_default = r'^[A-Za-z1-9_]{16,48}$'
@@ -31,6 +33,7 @@ class RandomIdentifierTagTests(WebTest):
                 self.assertRegex(page, r'^[A-Za-z1-9_]{%d}$' % length)
 
 
+@tag('templatetags')
 class PublicIdFilterTests(WebTest):
     template_string = "{% load utils %}{{ my_obj|public_id }}"
 
@@ -74,6 +77,7 @@ class PublicIdFilterTests(WebTest):
                     self.assertEqual(page, hash_of_obj)
 
 
+@tag('templatetags')
 class CompactFilterTests(WebTest):
     def test_single_line(self):
         content = "  \t Nam  pretium\vturpis  et\tarcu.   \f"

--- a/tests/templatetags/test_variable_tags.py
+++ b/tests/templatetags/test_variable_tags.py
@@ -1,0 +1,403 @@
+import string
+
+from django.template import Context, Template, TemplateSyntaxError
+from django.test import tag
+
+from django_webtest import WebTest
+
+
+@tag('templatetags')
+class MakeVariableTagTests(WebTest):
+    class DummyView(object):
+        @property
+        def simulate_role(self):
+            return "ADMIN"
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.test_data = [
+            ("Praesent congue erat at massa.", "Praesent congue erat at massa."),
+            ("<img src='7.png' width=\"51\" />", "<img src='7.png' width=\"51\" />"),
+            ("<script>alert(1); //&2^</script>", "<script>alert(1); //&2^</script>"),
+            ("{{ view.simulate_role }}", "ADMIN"),
+            ("{{ view.public_attr.0 }}", ""),
+            ("{{ short_name|add:' ' }}", " "),
+            ("<em>{{ long_var_name }}</em>", "<em>{}</em>".format(cls.__name__)),
+            ("{{ True }}", "True"),
+            ("~{{ _('Meenuu') }}~", "~Meenuu~"),
+        ]
+
+    @property
+    def base_context(self):
+        return {
+            'long_var_name': self.__class__.__name__,
+            'view': self.DummyView(),
+        }
+
+    def test_incorrect_syntax(self):
+        with self.assertRaises(TemplateSyntaxError) as cm:
+            Template("{% load variable %}{% asvar %}")
+        self.assertIn("Variable name is required", str(cm.exception))
+
+        for content in ("view.public_key", "42 + 24", "global ^X", "~~~ trimmed", "trimmed global"):
+            with self.subTest(tag_content=content):
+                with self.assertRaises(TemplateSyntaxError) as cm:
+                    Template(string.Template("{% load variable %}{% asvar $CONTENT %}").substitute(CONTENT=content))
+                self.assertIn("Syntax is {% asvar", str(cm.exception))
+
+        with self.assertRaises(TemplateSyntaxError) as cm:
+            Template("{% load variable %}{% asvar test %}")
+        self.assertIn("Unclosed tag on line 1: 'asvar'", str(cm.exception))
+
+    def test_underscored_variable(self):
+        for content in ("_x", "global _y", "_z trimmed", "global _A trimmed"):
+            with self.subTest(tag_content=content):
+                with self.assertRaises(TemplateSyntaxError) as cm:
+                    Template(string.Template("{% load variable %}{% asvar $CONTENT %}").substitute(CONTENT=content))
+                self.assertIn("Variables may not begin with underscores", str(cm.exception))
+
+    def test_stored_result(self):
+        template_string_clear = string.Template(
+            "{% load variable %} {% asvar test_var %}$TESTCONTENT{% endasvar %}")
+        template_string_print = string.Template(
+            "{% load variable %} {% asvar test_var %}$TESTCONTENT{% endasvar %}#{{ test_var }}#")
+
+        for content, expected in self.test_data:
+            with self.subTest(tag_content=content):
+                template = Template(template_string_clear.substitute(TESTCONTENT=content))
+                context = Context(self.base_context.copy())
+                page = template.render(context)
+                # Just storing the value in a context variable is expected to produce no output.
+                self.assertEqual(page, " ")
+
+                template = Template(template_string_print.substitute(TESTCONTENT=content))
+                context = Context(self.base_context.copy())
+                page = template.render(context)
+                # Using the stored context variable is expected to produce output.
+                self.assertEqual(page, " #{}#".format(expected))
+
+    def test_stored_locally_result(self, is_global=False, is_builtin=False):
+        template_string = string.Template("""
+            {% load variable %}
+            ^{{ $VARNAME }}^
+            {% with local_context=True %}
+                {% asvar $GLOBAL $VARNAME %}$TESTCONTENT{% endasvar %}
+                #{{ $VARNAME }}#
+            {% endwith %}
+            *{{ $VARNAME }}*
+        """)
+
+        for var_name in ('test_var', 'qwe_rty_uio_p9', 'global') if not is_builtin else ('False', 'None'):
+            for content, expected in self.test_data:
+                with self.subTest(tag_content=content, var=var_name):
+                    template = Template(template_string.substitute(
+                        TESTCONTENT=content, VARNAME=var_name, GLOBAL="global" if is_global else "",
+                    ))
+                    context = Context(self.base_context.copy())
+                    page = template.render(context)
+                    self.assertEqual(
+                        page.replace(" "*16, "").replace(" "*12, "").strip(),
+                        "^{value_builtin}^\n\n\n#{value_local}#\n\n*{value_global}*".format(
+                            value_local=expected,
+                            value_builtin=var_name if is_builtin else "",
+                            value_global=expected if is_global else (var_name if is_builtin else ""))
+                    )
+
+    def test_stored_globally_result(self):
+        self.test_stored_locally_result(is_global=True)
+
+    def test_builtin_override_locally(self):
+        self.test_stored_locally_result(is_builtin=True)
+
+    def test_builtin_override_globally(self):
+        self.test_stored_locally_result(is_builtin=True, is_global=True)
+
+    def test_trimmed_result(self):
+        template_string = string.Template("""
+            {% load variable %}
+            ^{{ $VARNAME }}^
+            {% asvar $VARNAME trimmed %}
+                \r  $TESTCONTENT \t $TESTCONTENT  \v
+            {% endasvar %}
+            #{{ $VARNAME }}#
+        """)
+
+        for var_name, var_override in (('test_var', False),
+                                       ('long_var_name', True),
+                                       ('global_', False),
+                                       ('None', True)):
+            for content, expected in self.test_data:
+                with self.subTest(tag_content=content, var=var_name):
+                    template = Template(template_string.substitute(
+                        TESTCONTENT=content, VARNAME=var_name,
+                    ))
+                    context = Context(self.base_context.copy())
+                    original_value = context[var_name] if var_override else ""
+                    page = template.render(context)
+                    self.assertEqual(
+                        page.replace(" "*12, "").strip(),
+                        "^{value_before}^\n\n#{value_after}#".format(
+                            value_before=original_value,
+                            value_after="{0} \t {0}".format(expected) if expected.strip() != "" else "")
+                    )
+
+    def test_confusing_variable(self):
+        combinations = (
+            # A combination of 'global global trimmed' is expected to produce a variable
+            # named 'global' in the top-level context, with whitespace in contents removed.
+            ('global global trimmed',
+             lambda v: {'local_full_var': v if v.strip() else "",
+                        'local_trim_var': "",
+                        'global_full_var': v if v.strip() else "",
+                        'global_trim_var': ""}),
+            # A combination of 'global trimmed trimmed' is expected to produce a variable
+            # named 'trimmed' in the top-level context, with whitespace in contents removed.
+            ('global trimmed trimmed',
+             lambda v: {'local_full_var': "",
+                        'local_trim_var': v if v.strip() else "",
+                        'global_full_var': "",
+                        'global_trim_var': v if v.strip() else ""}),
+            # A combination of 'global global' is expected to produce a variable
+            # named 'global' in the top-level context, with whitespace in contents preserved.
+            ('global global',
+             lambda v: {'local_full_var': "\n{s1}{content}\n{s2}".format(content=v, s1=" "*28, s2=" "*24),
+                        'local_trim_var': "",
+                        'global_full_var': "\n{s1}{content}\n{s2}".format(content=v, s1=" "*28, s2=" "*24),
+                        'global_trim_var': ""}),
+            # A combination of 'trimmed trimmed' is expected to produce a variable
+            # named 'trimmed' in the bottom-level context, with whitespace in contents removed.
+            ('trimmed trimmed',
+             lambda v: {'local_full_var': "",
+                        'local_trim_var': v if v.strip() else "",
+                        'global_full_var': "",
+                        'global_trim_var': ""}),
+            # A combination of 'global trimmed' is expected to produce a variable
+            # named 'trimmed' in the top-level context, with whitespace in contents preserved.
+            ('global trimmed',
+             lambda v: {'local_full_var': "",
+                        'local_trim_var': "\n{s1}{content}\n{s2}".format(content=v, s1=" "*28, s2=" "*24),
+                        'global_full_var': "",
+                        'global_trim_var': "\n{s1}{content}\n{s2}".format(content=v, s1=" "*28, s2=" "*24)}),
+        )
+
+        for combi, expected_vars in combinations:
+            with self.subTest(combi=combi):
+                template_string = string.Template("""
+                    {% load variable %}
+                    {% with local_context=True %}
+                        {% asvar $COMBINATION %}
+                            $TESTCONTENT
+                        {% endasvar %}
+                        ^{{ global }}^@{{ trimmed }}@
+                    {% endwith %}
+                    #{{ global }}#*{{ trimmed }}*
+                """)
+                for content, expected in self.test_data:
+                    with self.subTest(tag_content=content):
+                        template = Template(template_string.substitute(COMBINATION=combi, TESTCONTENT=content))
+                        context = Context(self.base_context.copy())
+                        page = template.render(context)
+                        self.assertEqual(
+                            page.strip(),
+                            "^{local_full_var}^@{local_trim_var}@"
+                            "{space}"
+                            "#{global_full_var}#*{global_trim_var}*".format(
+                                space=("\n"+" "*20)*2, **expected_vars(expected))
+                        )
+
+
+@tag('templatetags')
+class DeleteVariableTagTests(WebTest):
+    test_value = "Praesent congue erat at massa."
+
+    def test_incorrect_syntax(self):
+        with self.assertRaises(TemplateSyntaxError) as cm:
+            Template("{% load variable %}{% delvar %}")
+        self.assertIn("At least one variable name is required", str(cm.exception))
+
+        for content in ("view.public_key", "42 + 24", "global ^X", "~~~ trimmed", "trimmed:global"):
+            with self.subTest(tag_content=content):
+                with self.assertRaises(TemplateSyntaxError) as cm:
+                    Template(string.Template("{% load variable %}{% delvar $CONTENT %}").substitute(CONTENT=content))
+                self.assertIn("Syntax is {% delvar", str(cm.exception))
+
+        with self.assertRaises(TemplateSyntaxError) as cm:
+            Template("{% load variable %}{% delvar test %}{% enddelvar %}")
+        self.assertIn("Invalid block tag on line 1: 'enddelvar'", str(cm.exception))
+
+    def test_underscored_variables(self):
+        for content in ("_x", "x _y z", "global _A", "_b _trimmed", "global c trimmed _"):
+            with self.subTest(tag_content=content):
+                with self.assertRaises(TemplateSyntaxError) as cm:
+                    Template(string.Template("{% load variable %}{% delvar $CONTENT %}").substitute(CONTENT=content))
+                self.assertIn("Variables may not begin with underscores", str(cm.exception))
+
+    def test_one_variable(self):
+        template_string = """
+            {% load variable %}
+            ^{{ test }}^
+            {% delvar test %}
+            #{{ test }}#
+        """
+        template = Template(template_string)
+        context = Context({'test': self.test_value})
+        page = template.render(context)
+        self.assertEqual(
+            page.strip(),
+            "^{value_before}^{space}#{value_after}#".format(
+                value_before=self.test_value,
+                value_after="",
+                space=("\n"+" "*12)*2)
+        )
+
+    def test_existing_variable(self):
+        template_string = """
+            {% load variable %}
+            ^{{ testA }}^{{ testB }}^{{ testC }}^
+            {% delvar testB %}
+            #{{ testA }}#{{ testB }}#{{ testC }}#
+        """
+        template = Template(template_string)
+        context = Context({'testA': self.test_value, 'testB': "<script>alert(2);", 'testC': self.test_value})
+        page = template.render(context)
+        self.assertEqual(
+            page.strip(),
+            "^{value_a_before}^{value_b_before}^{value_c_before}^"
+            "{space}"
+            "#{value_a_after}#{value_b_after}#{value_c_after}#".format(
+                value_a_before=self.test_value,
+                value_a_after=self.test_value,
+                value_b_before="&lt;script&gt;alert(2);",
+                value_b_after="",
+                value_c_before=self.test_value,
+                value_c_after=self.test_value,
+                space=("\n"+" "*12)*2)
+        )
+
+    def test_nonexistent_variable(self):
+        template_string = """
+            {% load variable %}
+            ^{{ testA }}^{{ testB }}^
+            {% delvar testB %}
+            #{{ testA }}#{{ testB }}#
+        """
+        template = Template(template_string)
+        context = Context({'testA': self.test_value})
+        page = template.render(context)
+        self.assertEqual(
+            page.strip(),
+            "^{content}^^{space}#{content}##".format(content=self.test_value, space=("\n"+" "*12)*2)
+        )
+
+    def test_variable_in_local_context(self):
+        template_string = """
+            {% load variable %}
+            {% with local_context=True %}
+                {% delvar test %}
+            {% endwith %}
+            #{{ test }}#
+        """
+        template = Template(template_string)
+        context = Context({'test': self.test_value})
+        page = template.render(context)
+        self.assertEqual(page.strip(), "#{content}#".format(content=self.test_value))
+
+    def test_many_variables(self):
+        template_string = """
+            {% load variable %}
+            ^{{ testA }}^{{ testB }}^{{ testC }}^
+            {% delvar testC testD testA testB testA %}
+            #{{ testA }}#{{ testB }}#{{ testC }}#
+        """
+        template = Template(template_string)
+        context = Context({'testA': self.test_value, 'testB': self.test_value, 'testC': self.test_value})
+        page = template.render(context)
+        self.assertEqual(
+            page.strip(),
+            "^{value_before}^{value_before}^{value_before}^{space}####".format(
+                value_before=self.test_value,
+                space=("\n"+" "*12)*2)
+        )
+
+    def test_global_variable(self):
+        template_string = """
+            {% load variable %}
+            ^{{ testA }}^{{ True }}^{{ testB }}^
+            {% with local_context=True %}
+                {% delvar global testB testA %}
+            {% endwith %}
+            #{{ testA }}#{{ True }}#{{ testB }}#
+        """
+        template = Template(template_string)
+        context = Context({'testB': self.test_value})  # A value in a middle-level context.
+        context.dicts[0]['testA'] = self.test_value  # A value in the top-level context.
+        page = template.render(context)
+        self.assertEqual(
+            " ".join(page.split()),
+            "^{content}^True^{content}^ ##True#{content}#".format(content=self.test_value)
+        )
+
+    def test_builtin_variable(self):
+        # Removal of a global built-in value (True, False, None) is expected to restore the original value.
+        template_string = string.Template("""
+            {% load variable i18n %}
+            ^{{ $BUILTIN }}^
+            {% trans "Praesent turpis." as $BUILTIN %}
+            *{{ $BUILTIN }}*
+            {% delvar $BUILTIN %}
+            @{{ $BUILTIN }}@
+            {% delvar $BUILTIN %}
+            @{{ $BUILTIN }}@
+            {% delvar global $BUILTIN %}
+            #{{ $BUILTIN }}#
+        """)
+        for builtin in ('True', 'False', 'None'):
+            with self.subTest(builtin=builtin):
+                template = Template(template_string.substitute(BUILTIN=builtin))
+                context = Context({})
+                context.dicts[0][builtin] = "Totoro"  # Simulate an overriden global built-in.
+                page = template.render(context)
+                self.assertEqual(
+                    " ".join(page.split()),
+                    "^Totoro^ *Praesent turpis.* @Totoro@ @Totoro@ #{}#".format(builtin)
+                )
+
+    def test_confusing_variable(self):
+        # The usage of 'global' is expected to remove a variable called "global" from
+        # the context, if such variable exists.
+        template = Template("{% load variable %}{% delvar global %}{{ global }}")
+
+        context = Context({})
+        self.assertNotIn('global', context)
+        page = template.render(context)
+        self.assertNotIn('global', context)
+        self.assertEqual(page, "")
+
+        context = Context({'global': self.test_value})
+        self.assertIn('global', context)
+        page = template.render(context)
+        self.assertNotIn('global', context)
+        self.assertEqual(page, "")
+
+        # The usage of 'global global' is expected to remove a variable called "global" from
+        # the top-level context, but not other levels of the context, if such variable exists.
+        template = Template("{% load variable %}{% delvar global global %}{{ global }}")
+
+        context = Context({})
+        self.assertNotIn('global', context)
+        page = template.render(context)
+        self.assertNotIn('global', context)
+        self.assertEqual(page, "")
+
+        context = Context({'global': self.test_value})
+        self.assertIn('global', context)
+        page = template.render(context)
+        self.assertIn('global', context)
+        self.assertEqual(page, self.test_value)
+
+        context = Context({})
+        context.dicts[0]['global'] = "Satsuki"  # Simulate a variable in the top-level context.
+        self.assertIn('global', context)
+        page = template.render(context)
+        self.assertNotIn('global', context)
+        self.assertEqual(page, "")


### PR DESCRIPTION
**Aldonoj:**

- butonoj por rapida redakto de diversaj kromaj informeroj de la gastiganto, en la revizia paĝo
- en la revizia paĝo, ĉiuj telefonnumeroj de la gastiganto estas ĉiam montritaj, sed tiuj kiuj ne respondas al la reviziata kondiĉo (aŭ estas kaŝitaj fare de la uzanto) aperas duon-diafane
- en la profila paĝo kaj en la ejo-paĝo, tempo-indikoj pri lasta redakto

**Korektoj:**

- en la administrilo, grupoj kiuj ne reprezentas landojn ne estu uzataj rilate al landaj organizantoj
- kontrolo ankaŭ pri majusklaj surogataj E-literoj (S^, ~U)
- kiam mankas tempo-indiko, aperu “neniam”
- kontrolado de gastigantoj estas ebla sendepende de havebleco/dezirindeco de JS
- kontrolado/aprobado de gastigantoj en la libro!