### PR TITLE
Anstataŭigas Supervisord per Systemd

### DIFF
--- a/etc/gunicorn_config.py.example
+++ b/etc/gunicorn_config.py.example
@@ -9,4 +9,4 @@ pythonpath = '/srv/prod/pasportaservo'
 bind = ['127.0.0.1:8010', '[::1]:8010']
 workers = 3
 user = 'ps'
-errorlog = '../stderr.log'
+errorlog = '/srv/staging/stderr.log'

--- a/etc/supervisor/prod.conf
+++ b/etc/supervisor/prod.conf
@@ -1,6 +1,0 @@
-[program:prod]
-command = /opt/envs/prod/bin/python /opt/envs/prod/bin/gunicorn -c /srv/prod/gunicorn_config.py pasportaservo.wsgi
-directory = /srv/prod/pasportaservo
-user = ps
-autostart = true
-autorestart = true

--- a/etc/supervisor/staging.conf
+++ b/etc/supervisor/staging.conf
@@ -1,6 +1,0 @@
-[program:staging]
-command = /opt/envs/staging/bin/python /opt/envs/staging/bin/gunicorn -c /srv/staging/gunicorn_config.py pasportaservo.wsgi
-directory = /srv/staging/pasportaservo
-user = ps
-autostart = true
-autorestart = true

--- a/etc/systemd/system/pasportaservo.prod.service
+++ b/etc/systemd/system/pasportaservo.prod.service
@@ -1,0 +1,16 @@
+[Unit]
+Description=Pasporta Servo https://www.pasportaservo.org
+After=network-online.target
+
+[Service]
+ExecStart=/opt/envs/prod/bin/python /opt/envs/prod/bin/gunicorn -c /srv/prod/gunicorn_config.py pasportaservo.wsgi
+WorkingDirectory=/srv/prod/pasportaservo
+RuntimeDirectory=pasportaservo
+User=ps
+Restart=on-failure
+RestartSec=1
+KillSignal=SIGQUIT
+StandardError=syslog
+
+[Install]
+WantedBy=multi-user.target

--- a/etc/systemd/system/pasportaservo.staging.service
+++ b/etc/systemd/system/pasportaservo.staging.service
@@ -1,0 +1,16 @@
+[Unit]
+Description=Pasporta Servo staging (UAT) https://ido.pasportaservo.org
+After=network-online.target
+
+[Service]
+ExecStart=/opt/envs/staging/bin/python /opt/envs/staging/bin/gunicorn -c /srv/staging/gunicorn_config.py pasportaservo.wsgi
+WorkingDirectory=/srv/staging/pasportaservo
+RuntimeDirectory=pasportaservo
+User=ps
+Restart=on-failure
+RestartSec=1
+KillSignal=SIGQUIT
+StandardError=syslog
+
+[Install]
+WantedBy=multi-user.target

--- a/fabfile.py
+++ b/fabfile.py
@@ -80,7 +80,7 @@ def updatestrings(runlocal=True, _inside_env=False):
 def updatestatic():
     run("./manage.py compilejsi18n -l eo")
     run("./manage.py compilescss")
-    run("./manage.py collectstatic --noinput %s" %
+    run("./manage.py collectstatic -v0 --noinput %s" %
         ("--ignore=*.scss" if env.site == 'prod' else ""))
     run("./manage.py compress --force")
 
@@ -111,4 +111,4 @@ def deploy(mode='full', remote='origin'):
 def site_ctl(command):
     require('site', provided_by=[staging, prod])
 
-    sudo("supervisorctl %s %s" % (command, env.site))
+    sudo("systemctl %s pasportaservo.%s.service" % (command, env.site))


### PR DESCRIPTION
https://vsupalov.com/django-systemd-crashcourse/

Ni ne forgesu fari la jenan rekte sur la servilo:
```shell
sudo systemctl daemon-reload

sudo systemctl enable pasportaservo.staging.service
sudo supervisorctl stop staging
sudo systemctl start pasportaservo.staging.service

sudo systemctl enable pasportaservo.prod.service
sudo supervisorctl stop prod
sudo systemctl start pasportaservo.prod.service
```