### PR TITLE
Rendimento de la ekstera interfaco (frontend performance)

### DIFF
--- a/core/context_processors.py
+++ b/core/context_processors.py
@@ -8,6 +8,8 @@ def expose_selected_settings(request):
         'REDIRECT_FIELD_NAME',
         'INVALID_PREFIX',
         'MAPBOX_GL_CSS',
+        'MAPBOX_GL_CSS_INTEGRITY',
         'MAPBOX_GL_JS',
+        'MAPBOX_GL_JS_INTEGRITY',
     ]
     return {name: getattr(settings, name) for name in SETTINGS}

--- a/core/static/sass/_fonts.scss
+++ b/core/static/sass/_fonts.scss
@@ -4,7 +4,7 @@
          url('../fonts/Geotica_Three.woff')  format('woff');
 }
 
-@import url('https://fonts.googleapis.com/css?family=Fira+Sans:200,200i,400,400i,700,700i|Fira+Mono:400|PT+Sans:400,400i,700,700i&subset=latin-ext,vietnamese');
+@import url('https://fonts.googleapis.com/css?family=Fira+Sans:200,200i,400,400i,700,700i|Fira+Mono:400|PT+Sans:400,400i,700,700i&subset=latin-ext');
 
 @font-face {
     font-family: "PS Signaro";
@@ -15,6 +15,7 @@
          url('../fonts/PS-Signaro.svg?v=1.0#PS-Signaro') format('svg');
     font-weight: normal;
     font-style: normal;
+    font-display: block;
 }
 
 $font-stack: "Fira Sans", "Trebuchet MS", Helvetica, Tahoma, sans-serif;
@@ -23,8 +24,8 @@ $font-stack-hint: "PT Sans", Helvetica, Arial, sans-serif;
 
 
 .fa {
-  /* use !important to prevent issues with browser extensions that change fonts */
-  font-family: "PS Signaro", FontAwesome !important;
+    /* use !important to prevent issues with browser extensions that change fonts */
+    font-family: "PS Signaro", FontAwesome !important;
 }
 .ps {
     &-home:before {

--- a/core/templates/base.html
+++ b/core/templates/base.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-{% load i18n statici18n static compress sass_tags utils %}
+{% load i18n statici18n static cdn compress sass_tags utils %}
 
 <html lang="eo" class="{% if ' MSIE ' in request.META.HTTP_USER_AGENT or 'Trident/' in request.META.HTTP_USER_AGENT %}msie-compat{% endif %}">
     <head>
@@ -31,14 +31,42 @@
         <link rel="alternate" type="application/atom+xml" title="Pasporta Servo: {% trans "News" %}" href="{% url 'blog:atom' %}">
         <link rel="search" title="{% trans "Search" %} {% trans "at" %} Pasporta Servo" href="{% url 'search' %}">
 
-        <link rel="stylesheet" href="{% static 'bootstrap/css/bootstrap.min.css' %}">
+        {% if 'cdn' in request.GET.accelerate %}
+            <link rel="preconnect" href="{% cdn %}" crossorigin>
+        {% endif %}
+        {% if 'bs-css' in request.GET.accelerate %}
+            <link rel="preload"    href="{% cdn 'bootstrap' '3.4.1' %}/css/bootstrap.min.css" as="style" crossorigin>
+            <link rel="stylesheet" href="{% cdn 'bootstrap' '3.4.1' %}/css/bootstrap.min.css" crossorigin="anonymous"
+                                   integrity="sha256-bZLfwXAP04zRMK2BjiO8iu9pf4FbLqX6zitd+tIvLhE=" referrerpolicy="origin-when-cross-origin">
+        {% else %}
+            <link rel="stylesheet" href="{% static 'bootstrap/css/bootstrap.min.css' %}">
+        {% endif %}
+        {% if 'localfonts' in request.GET.accelerate %}
+            <link rel="preload"    href="{% static 'bootstrap/fonts/fontawesome-webfont.woff2' %}?v=4.7.0" as="font" type="font/woff2" crossorigin>
+            <link rel="preload"    href="{% static 'fonts/PS-Signaro.woff' %}?v=1.0" as="font" type="font/woff" crossorigin>
+            <link rel="preload"    href="{% static 'fonts/Geotica_Three.woff2' %}" as="font" type="font/woff2" crossorigin>
+        {% endif %}
         <link rel="stylesheet" href="{% static 'bootstrap/css/font-awesome.min.css' %}">
+        {% if 'gfonts' in request.GET.accelerate %}
+            <link rel="preconnect" href="https://fonts.gstatic.com/" crossorigin>
+        {% endif %}
         {% compress css %}
             <link rel="stylesheet" href="{% sass_src 'css/pasportaservo.scss' %}">
             {% block extra_css %}{% endblock %}
         {% endcompress %}
-        <script src="{% static 'js/jquery.min.js' %}"></script>
-        <script src="{% static 'bootstrap/js/bootstrap.min.js' %}"></script>
+
+        {% if 'jq' in request.GET.accelerate %}
+            <script src="{% cdn 'jquery' '3.4.1' %}/jquery.min.js" crossorigin="anonymous"
+                    integrity="sha256-CSXorXvZcTkaix6Yvo6HppcZGetbYMGWSFlBw8HfCJo=" referrerpolicy="origin-when-cross-origin" {% if 'defer' in request.GET.accelerate %}defer{% endif %}></script>
+        {% else %}
+            <script src="{% static 'js/jquery.min.js' %}" {% if 'defer' in request.GET.accelerate %}defer{% endif %}></script>
+        {% endif %}
+        {% if 'bs-js' in request.GET.accelerate %}
+            <script src="{% cdn 'bootstrap' '3.4.1' %}/js/bootstrap.min.js" crossorigin="anonymous"
+                    integrity="sha256-nuL8/2cJ5NDSSwnKD8VqreErSWHtnEP9E7AySL+1ev4=" referrerpolicy="origin-when-cross-origin" {% if 'defer' in request.GET.accelerate %}defer{% endif %}></script>
+        {% else %}
+            <script src="{% static 'bootstrap/js/bootstrap.min.js' %}" {% if 'defer' in request.GET.accelerate %}defer{% endif %}></script>
+        {% endif %}
         {% compress js %}
             <script src="{% statici18n 'eo' %}"></script>
             <script src="{% static 'js/cookies.min.js' %}"></script>

--- a/core/templates/core/snippets/registration.html
+++ b/core/templates/core/snippets/registration.html
@@ -1,4 +1,4 @@
-{% load static compress bootstrap variable %}
+{% load static cdn compress bootstrap variable %}
 {% load trans blocktrans from i18n %}
 {% load next from utils %}
 
@@ -28,5 +28,5 @@
         <script src="{% static 'js/forms.js' %}"></script>
         <script src="{% static 'js/forms-validation.eo.js' %}"></script>
     {% endcompress %}
-    <script src="{% static 'pwstrength/js/zxcvbn.js' %}"></script>
+    <script src="{% cdn 'ps' %}/pasportaservo/static/pwstrength/js/zxcvbn.js" defer></script>
 </div>

--- a/core/templates/registration/password_change_form.html
+++ b/core/templates/registration/password_change_form.html
@@ -1,5 +1,5 @@
 {% extends 'core/base_form.html' %}
-{% load i18n bootstrap static %}
+{% load i18n cdn %}
 
 {% block head_title %}{% trans "Settings" %} &gt; {% trans "Change password" %}{% endblock %}
 {% block head_title_separator %}{% trans "at" %}{% endblock %}
@@ -11,5 +11,5 @@
 
 {% block body %}
     {{ block.super }}
-    <script src="{% static 'pwstrength/js/zxcvbn.js' %}"></script>
+    <script src="{% cdn 'ps' %}/pasportaservo/static/pwstrength/js/zxcvbn.js" defer></script>
 {% endblock %}

--- a/core/templates/registration/password_reset_confirm.html
+++ b/core/templates/registration/password_reset_confirm.html
@@ -1,5 +1,5 @@
 {% extends 'core/base_form.html' %}
-{% load i18n bootstrap static %}
+{% load i18n cdn %}
 
 {% block head_title %}{% trans "Password reset" %}{% endblock %}
 
@@ -46,5 +46,7 @@
 
 {% block body %}
     {{ block.super }}
-    <script src="{% static 'pwstrength/js/zxcvbn.js' %}"></script>
+    {% if form %}
+        <script src="{% cdn 'ps' %}/pasportaservo/static/pwstrength/js/zxcvbn.js" defer></script>
+    {% endif %}
 {% endblock %}

--- a/core/templates/registration/password_reset_form.html
+++ b/core/templates/registration/password_reset_form.html
@@ -1,5 +1,5 @@
 {% extends 'core/base_form.html' %}
-{% load i18n bootstrap %}
+{% load i18n %}
 
 {% block head_title %}{% trans "Password reset" %}{% endblock %}
 

--- a/core/templates/registration/register.html
+++ b/core/templates/registration/register.html
@@ -1,5 +1,5 @@
 {% extends 'core/base_form.html' %}
-{% load i18n bootstrap static %}
+{% load i18n cdn %}
 
 {% block head_title %}{% trans "Register" context "Imperative" %} &amp; {% trans "Find accommodation" %}{% endblock %}
 
@@ -10,5 +10,5 @@
 
 {% block body %}
     {{ block.super }}
-    <script src="{% static 'pwstrength/js/zxcvbn.js' %}"></script>
+    <script src="{% cdn 'ps' %}/pasportaservo/static/pwstrength/js/zxcvbn.js" defer></script>
 {% endblock %}

--- a/core/templatetags/cdn.py
+++ b/core/templatetags/cdn.py
@@ -1,0 +1,17 @@
+from django import template
+
+register = template.Library()
+
+
+@register.simple_tag
+def cdn(library='', version=None):
+    base = 'https://cdn.jsdelivr.net/'
+    if not library:
+        return base
+    if library == 'ps':
+        return '{}gh/tejoesperanto/pasportaservo@prod'.format(base)
+    if library == 'bootstrap':
+        return '{}gh/twbs/bootstrap{}{}/dist'.format(base, '@' if version else '', version or '')
+    if library == 'jquery':
+        return '{}gh/jquery/jquery{}{}/dist'.format(base, '@' if version else '', version or '')
+    return ''

--- a/etc/nginx/prod.conf
+++ b/etc/nginx/prod.conf
@@ -44,10 +44,12 @@ server {
 
     location /static {
         alias /srv/prod/www/static;
+        expires 1y;
     }
 
     location /media {
         alias /srv/prod/www/media;
+        expires 30d;
     }
 
     location /XXXX {

--- a/etc/nginx/staging.conf
+++ b/etc/nginx/staging.conf
@@ -38,6 +38,7 @@ server {
 
     location /static {
         alias /srv/staging/www/static;
+        expires 30d;
     }
 
     location /media {

--- a/etc/nginx/www.pasportaservo.conf
+++ b/etc/nginx/www.pasportaservo.conf
@@ -41,10 +41,12 @@ server {
 
     location /static {
         alias /srv/prod/www/static;
+        expires 1y;
     }
 
     location /media {
         alias /srv/prod/www/media;
+        expires 30d;
     }
 
     location / {

--- a/hosting/templates/hosting/place_detail.html
+++ b/hosting/templates/hosting/place_detail.html
@@ -36,8 +36,8 @@
         <script src="{% static 'maps/place-map.js' %}"></script>
 {% endblock extra_js %}
 {% block extra_head %}
-        <link rel="stylesheet" href="{{ MAPBOX_GL_CSS }}">
-        <script src="{{ MAPBOX_GL_JS }}"></script>
+        <link rel="stylesheet" href="{{ MAPBOX_GL_CSS }}" crossorigin="anonymous" integrity="{{ MAPBOX_GL_CSS_INTEGRITY }}" referrerpolicy="origin-when-cross-origin">
+        <script src="{{ MAPBOX_GL_JS }}" crossorigin="anonymous" integrity="{{ MAPBOX_GL_JS_INTEGRITY }}" referrerpolicy="origin-when-cross-origin" {% if 'defer' in request.GET.accelerate %}defer{% endif %}></script>
         <script src="{% url 'gis_endpoints' %}?format=js&type=place"></script>
 {% endblock %}
 

--- a/hosting/templates/hosting/place_list_supervisor.html
+++ b/hosting/templates/hosting/place_list_supervisor.html
@@ -11,8 +11,8 @@
         <script src="{% static 'maps/region-map.js' %}"></script>
 {% endblock %}
 {% block extra_head %}
-        <link rel="stylesheet" href="{{ MAPBOX_GL_CSS }}">
-        <script src="{{ MAPBOX_GL_JS }}"></script>
+        <link rel="stylesheet" href="{{ MAPBOX_GL_CSS }}" crossorigin="anonymous" integrity="{{ MAPBOX_GL_CSS_INTEGRITY }}" referrerpolicy="origin-when-cross-origin">
+        <script src="{{ MAPBOX_GL_JS }}" crossorigin="anonymous" integrity="{{ MAPBOX_GL_JS_INTEGRITY }}" referrerpolicy="origin-when-cross-origin"></script>
         <script src="{% url 'gis_endpoints' %}?format=js&type=region&country={{ view.country.code }}{% if view.in_book_status is not None %}&in_book={{ view.in_book_status|yesno:"1,0" }}{% endif %}"></script>
 {% endblock %}
 

--- a/maps/templates/maps/world_map.html
+++ b/maps/templates/maps/world_map.html
@@ -8,8 +8,8 @@
         <script src="{% static 'maps/world-map.js' %}"></script>
 {% endblock %}
 {% block extra_head %}
-        <link rel="stylesheet" href="{{ MAPBOX_GL_CSS }}">
-        <script src="{{ MAPBOX_GL_JS }}"></script>
+        <link rel="stylesheet" href="{{ MAPBOX_GL_CSS }}" crossorigin="anonymous" integrity="{{ MAPBOX_GL_CSS_INTEGRITY }}" referrerpolicy="origin-when-cross-origin">
+        <script src="{{ MAPBOX_GL_JS }}" crossorigin="anonymous" integrity="{{ MAPBOX_GL_JS_INTEGRITY }}" referrerpolicy="origin-when-cross-origin" {% if 'defer' in request.GET.accelerate %}defer{% endif %}></script>
         <script src="{% url 'gis_endpoints' %}?format=js&type=world"></script>
 {% endblock %}
 

--- a/pasportaservo/settings/base.py
+++ b/pasportaservo/settings/base.py
@@ -240,5 +240,7 @@ POSTMAN_NOTIFIER_APP = None
 
 MAPBOX_GL_BASE_STATIC = 'https://api.tiles.mapbox.com/mapbox-gl-js/v1.6.1/mapbox-gl.{ext}'
 MAPBOX_GL_CSS = MAPBOX_GL_BASE_STATIC.format(ext='css')
+MAPBOX_GL_CSS_INTEGRITY = 'sha256-3XLrPGRtUa2wjYwYlJ+zzTHDPxMjqezc0pW0z9p3wzM='
 MAPBOX_GL_JS = MAPBOX_GL_BASE_STATIC.format(ext='js')
+MAPBOX_GL_JS_INTEGRITY = 'sha256-wnlY/amZnNRLP46AkbAJD/YbtnMnq3XGoGX9+g6unUI='
 MAPBOX_GL_RTL_PLUGIN = 'https://api.mapbox.com/mapbox-gl-js/plugins/mapbox-gl-rtl-text/v0.2.3/mapbox-gl-rtl-text.js'

--- a/tests/assertions.py
+++ b/tests/assertions.py
@@ -1,18 +1,18 @@
 
 class AdditionalAsserts:
-    def assertSurrounding(self, string, prefix, postfix, msg=None):
+    def assertSurrounding(self, string, prefix=None, postfix=None, msg=None):
         """
         Asserts that the string has the given prefix and postfix.
         """
         if not isinstance(string, str):
             self.fail("First argument is not a string")
-        if not string.startswith(prefix):
+        if prefix and not string.startswith(prefix):
             self.fail(self._formatMessage(msg, "'{}' does not start with '{}'".format(
                 string[:len(prefix)+8]
                 + ("[...]" if len(string) > len(prefix)+10 else string[len(prefix)+10:]),
                 prefix
             )))
-        if not string.endswith(postfix):
+        if postfix and not string.endswith(postfix):
             self.fail(self._formatMessage(msg, "'{}' does not end with '{}'".format(
                 ("[...]" if len(string) > len(postfix)+10 else string[:-len(postfix)-8])
                 + string[-len(postfix)-8:],

--- a/tests/context_processors/test_ctx_processors.py
+++ b/tests/context_processors/test_ctx_processors.py
@@ -8,6 +8,8 @@ class CoreContextProcessorTests(WebTest):
         response = self.app.get('/', status=200)
         for setting in ('MAPBOX_GL_CSS',
                         'MAPBOX_GL_JS',
+                        'MAPBOX_GL_CSS_INTEGRITY',
+                        'MAPBOX_GL_JS_INTEGRITY',
                         'INVALID_PREFIX',
                         'SUPPORT_EMAIL',
                         'REDIRECT_FIELD_NAME',

--- a/tests/templatetags/test_cdn_tag.py
+++ b/tests/templatetags/test_cdn_tag.py
@@ -1,0 +1,59 @@
+import string
+
+from django.template import Context, Template
+from django.test import TestCase, tag
+
+from ..assertions import AdditionalAsserts
+
+
+@tag('templatetags')
+class CdnTagTests(AdditionalAsserts, TestCase):
+    cdn_base = 'https://cdn.jsdelivr.net/'
+
+    def test_base(self):
+        page = Template("{% load cdn %}{% cdn %}").render(Context())
+        self.assertEqual(page, self.cdn_base)
+
+        page = Template("{% load cdn %}{% cdn version=1.2.3 %}").render(Context())
+        self.assertEqual(page, self.cdn_base)
+
+    def test_ps_cdn(self):
+        expected_url = 'gh/tejoesperanto/pasportaservo@prod'
+
+        page = Template("{% load cdn %}{% cdn 'ps' %}").render(Context())
+        self.assertEqual(page, '{}{}'.format(self.cdn_base, expected_url))
+
+        page = Template("{% load cdn %}{% cdn 'ps' '1.2.3' %}").render(Context())
+        self.assertEqual(page, '{}{}'.format(self.cdn_base, expected_url))
+
+        page = Template("{% load cdn %}{% cdn version='1.2.3' library='ps' %}").render(Context())
+        self.assertEqual(page, '{}{}'.format(self.cdn_base, expected_url))
+
+    def test_library_cdn(self):
+        test_data = {
+            'jquery': '/jquery/jquery',
+            'bootstrap': '/twbs/bootstrap',
+        }
+        template_string = string.Template("{% load cdn %}{% cdn '$LIB' $VER %}")
+        for library, path in test_data.items():
+            for version in (None, 12.3, 'alpha', '77p1-dev4'):
+                with self.subTest(library=library, version=version):
+                    template = Template(template_string.substitute(
+                        LIB=library,
+                        VER='"{}"'.format(version) if isinstance(version, str) else (version or '')
+                    ))
+                    page = template.render(Context())
+                    self.assertSurrounding(page, prefix=self.cdn_base)
+                    self.assertIn(path + ('@' if version else '/'), page)
+                    if version is not None:
+                        self.assertIn('@{}'.format(version), page)
+
+    def test_unknown_library(self):
+        page = Template("{% load cdn %}{% cdn 'qwerty' %}").render(Context())
+        self.assertEqual(page, "")
+        page = Template("{% load cdn %}{% cdn 'qwerty' '999.88.7' %}").render(Context())
+        self.assertEqual(page, "")
+        page = Template("{% load cdn %}{% cdn '999.88.7' %}").render(Context())
+        self.assertEqual(page, "")
+        page = Template("{% load cdn %}{% cdn version='999.88.7' library='asdf' %}").render(Context())
+        self.assertEqual(page, "")


### PR DESCRIPTION
La enmeto inkluzivas diversajn testojn kiujn eblas konduki sur paĝoj de la retejo por ekzameni “en reala mondo” kiuj ŝanĝoj plibonigos la rendimenton (ĉefe la ŝargo-tempojn). Bedaŭrinde, loke sur testa maŝino tiaj testoj ne donas sencan respondon.
Post ekzameni sur `ido`, ni povus decidi kiujn ŝanĝojn lasi kaj kiujn forĵeti.