### PR TITLE
Ĝisdatigo de la SSL/TLS agordojn por A+ grade

### DIFF
--- a/etc/nginx/nginx.conf
+++ b/etc/nginx/nginx.conf
@@ -34,9 +34,9 @@ http {
 	# SSL Settings
 	##
 
-	ssl_protocols TLSv1 TLSv1.1 TLSv1.2; # Dropping SSLv3, ref: POODLE
-	ssl_prefer_server_ciphers on;
-	ssl_ciphers 'ECDHE+CHACHA20:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-RSA-AES128-GCM-SHA256:ECDHE+AES256+SHA384:ECDHE+AES256+SHA';
+	ssl_protocols TLSv1.2 TLSv1.3;
+	ssl_ciphers ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384;
+	ssl_prefer_server_ciphers off;
 
 	##
 	# Logging Settings
@@ -50,8 +50,6 @@ http {
 	##
 
 	gzip on;
-	gzip_disable "msie6";
-
 	gzip_vary on;
 	gzip_proxied any;
 	gzip_comp_level 6;


### PR DESCRIPTION
Laŭ Qualys SSL Lab, la retejo iĝis :b: pro subteno de TLS < 1.2.  
Ni igu Pasporta Servo mojose denove! :muscle: :a::heavy_plus_sign: 

- [x] Forigas TLS v1.0 kaj  v1.1
- [X] Ĝisdatigas la ĉifriloj laŭ la [listo de Mozilla](https://ssl-config.mozilla.org/#server=nginx&version=1.14.2&config=intermediate&openssl=1.1.1d&guideline=5.4)