### PR TITLE
Riparas ORM-peton por Django 2

### DIFF
--- a/blog/models.py
+++ b/blog/models.py
@@ -13,8 +13,8 @@ from simplemde.fields import SimpleMDEField
 
 
 class PublishedQueryset(models.QuerySet):
-    def published(self, limit=50):
-        return self.filter(published=True)[:limit]
+    def published(self):
+        return self.filter(published=True)
 
 
 class PublishedManager(models.Manager):
@@ -33,8 +33,8 @@ class PublishedManager(models.Manager):
             ),
         )
 
-    def published(self, limit=50):
-        return self.get_queryset().published(limit)
+    def published(self):
+        return self.get_queryset().published()
 
 
 class Post(TimeStampedModel):

--- a/blog/tests/test_blog_models.py
+++ b/blog/tests/test_blog_models.py
@@ -180,23 +180,17 @@ class PublishedManagerTests(WebTest):
 
     def test_published(self):
         Post.objects.bulk_create(
-            PostFactory.build_batch(10)
+            PostFactory.build_batch(2)
             + PostFactory.build_batch(3, is_published=False)
             + PostFactory.build_batch(3, will_be_published=True)
         )
         mgr = Post.objects
-
-        # The default paging is expected to be 50.
-        # self.assertEqual(len(mgr.published()), 50)
-        for n in (10, 6, 3):
-            with self.subTest(limit=n):
-                # Limiting the number of published posts is expected to return the requested number.
-                posts = mgr.published(limit=n)
-                this_day = timezone.now()
-                self.assertEqual(len(posts), n)
-                for i in range(1, n):
-                    with self.subTest(post_date=posts[i].pub_date):
-                        self.assertLessEqual(posts[i].pub_date, this_day)
+        posts = mgr.published()
+        this_day = timezone.now()
+        self.assertEqual(len(posts), 2)
+        for i in range(2):
+            with self.subTest(post_date=posts[i].pub_date):
+                self.assertLessEqual(posts[i].pub_date, this_day)
 
     def test_published_with_no_posts(self):
         mgr = Post.objects

--- a/blog/tests/test_blog_views.py
+++ b/blog/tests/test_blog_views.py
@@ -1,0 +1,12 @@
+from django.urls import reverse
+
+from django_webtest import WebTest
+
+from .factories import PostFactory
+
+
+class PostViewTests(WebTest):
+    def test_prev_next(self):
+        post = PostFactory()
+        url = reverse('blog:post', kwargs={"slug": post.slug})
+        self.app.get(url, status=200)

--- a/blog/views.py
+++ b/blog/views.py
@@ -28,7 +28,7 @@ class PostsFeed(Feed):
     description = _("The last news about Pasporta Servo")
 
     def items(self):
-        return Post.objects.published(10)
+        return Post.objects.published()[:10]
 
     def item_title(self, item):
         return item.title

--- a/core/views.py
+++ b/core/views.py
@@ -58,7 +58,7 @@ class HomeView(generic.TemplateView):
 
     @cached_property
     def news(self):
-        return Post.objects.published(3).defer('content', 'body')
+        return Post.objects.published().defer('content', 'body')[:3]
 
     @cached_property
     def right_block(self):


### PR DESCRIPTION
Riparas [`#PS-C` en (Sentry)](https://sentry.io/organizations/pasporta-servo/issues/1556188771/)

```
TypeError: Cannot reverse a query once a slice has been taken.
```