### PR TITLE
Adresoj: Reguligo de administraj lando-eroj

### DIFF
--- a/book/management/commands/base.py
+++ b/book/management/commands/base.py
@@ -13,7 +13,8 @@ from django.utils import translation
 from django_countries import countries
 
 from hosting.models import Place
-from maps import COUNTRIES_WITH_REGIONS
+
+COUNTRIES_WITH_REGIONS = ('BE', 'BR', 'CA', 'DE', 'FR', 'GB', 'US')
 
 
 class LatexCommand(object):

--- a/core/management/commands/update_country_regions.py
+++ b/core/management/commands/update_country_regions.py
@@ -30,7 +30,7 @@ from django_countries.data import COUNTRIES
 from unidecode import unidecode
 
 from hosting.countries import COUNTRIES_DATA
-from hosting.models import LOCATION_REGION, CountryRegion, Whereabouts
+from hosting.models import CountryRegion, LocationType, Whereabouts
 from maps import SRID
 
 GEONAMES_SOURCE_URL = (
@@ -413,7 +413,7 @@ class Command(BaseCommand):
             # Update the geographical data for the region.
             if 'bbox' in region:
                 Whereabouts.objects.update_or_create(
-                    type=LOCATION_REGION,
+                    type=LocationType.REGION,
                     state=region_code,
                     country=country_code,
                     defaults=dict(

--- a/hosting/admin/forms.py
+++ b/hosting/admin/forms.py
@@ -5,7 +5,9 @@ from django.utils.translation import ugettext_lazy as _
 
 from django_countries.fields import Country
 
-from maps import COUNTRIES_WITH_MANDATORY_REGION, SRID
+from maps import SRID
+
+from ..countries import countries_with_mandatory_region
 
 
 class WhereaboutsAdminForm(ModelForm):
@@ -30,7 +32,7 @@ class WhereaboutsAdminForm(ModelForm):
 
     def clean(self):
         cleaned_data = super().clean()
-        if cleaned_data.get('country') in COUNTRIES_WITH_MANDATORY_REGION and not cleaned_data.get('state'):
+        if cleaned_data.get('country') in countries_with_mandatory_region() and not cleaned_data.get('state'):
             # Verifies that the region is indeed indicated when it is mandatory.
             message = _("For an address in {country}, the name of the state or province must be indicated.")
             self.add_error('state', format_lazy(message, country=Country(cleaned_data['country']).name))

--- a/hosting/admin/forms.py
+++ b/hosting/admin/forms.py
@@ -8,7 +8,7 @@ from django_countries.fields import Country
 from maps import SRID
 
 from ..countries import countries_with_mandatory_region
-from ..models import LOCATION_CITY, LOCATION_REGION
+from ..models import LocationType
 
 
 class WhereaboutsAdminForm(ModelForm):
@@ -33,7 +33,8 @@ class WhereaboutsAdminForm(ModelForm):
 
     def clean(self):
         cleaned_data = super().clean()
-        if (cleaned_data.get('type') == LOCATION_CITY
+        whereabouts_type = LocationType(cleaned_data.get('type', LocationType.UNKNOWN))
+        if (whereabouts_type is LocationType.CITY
                 and cleaned_data.get('country') in countries_with_mandatory_region()
                 and not cleaned_data.get('state')):
             # Verifies that the region is indeed indicated when it is mandatory.
@@ -43,7 +44,8 @@ class WhereaboutsAdminForm(ModelForm):
                 'state',
                 format_lazy(message, country=Country(cleaned_data['country']).name)
             )
-        if (cleaned_data.get('type') == LOCATION_REGION and not cleaned_data.get('state')):
+        if (whereabouts_type is LocationType.REGION
+                and not cleaned_data.get('state')):
             # Verifies that a region has both name and code indicated.
             message = _("The 'state / province' field should indicate "
                         "the ISO code of the region.")

--- a/hosting/countries.py
+++ b/hosting/countries.py
@@ -4095,3 +4095,12 @@ COUNTRIES_DATA = {
         "postcode_format": ""
     }
 }
+
+
+def countries_with_mandatory_region():
+    if not hasattr(countries_with_mandatory_region, '_result_cache'):
+        countries_with_mandatory_region._result_cache = frozenset(
+            country_code for (country_code, data) in COUNTRIES_DATA.items()
+            if 'administrativeArea' in data.get('required_fields', [])
+        )
+    return countries_with_mandatory_region._result_cache

--- a/hosting/countries.py
+++ b/hosting/countries.py
@@ -8,6 +8,8 @@ copyright (c) 2014-2019 Bojan Zivanovic and contributors. It is complemented by
 information from GeoNames under the CC BY 4.0 license.
 """
 
+from django.utils.translation import pgettext_lazy
+
 COUNTRIES_DATA = {
     "AD": {
         "local_name": "Andorra",
@@ -166,7 +168,7 @@ COUNTRIES_DATA = {
             "organization",
             "administrativeArea"
         ],
-        "administrative_area_type": "state",
+        "administrative_area_type": "district",
         "administrative_area_code": "ADM1",
         "postal_code_type": "zip",
         "postcode_regex": "(96799)(?:[ \\-](\\d{4}))?",
@@ -342,6 +344,7 @@ COUNTRIES_DATA = {
         ],
         "population": 7000039,
         "format": "%givenName %familyName\\n%organization\\n%addressLine1\\n%addressLine2\\n%postalCode %locality",
+        "administrative_area_type": "oblast",
         "postcode_regex": "\\d{4}",
         "postcode_format": "####"
     },
@@ -530,6 +533,7 @@ COUNTRIES_DATA = {
         ],
         "population": 9485386,
         "format": "%administrativeArea\\n%postalCode %locality\\n%addressLine1\\n%addressLine2\\n%organization\\n%givenName %familyName",
+        "administrative_area_type": "oblast",
         "postcode_regex": "\\d{6}",
         "postcode_format": "######"
     },
@@ -1864,6 +1868,7 @@ COUNTRIES_DATA = {
         ],
         "population": 6315800,
         "format": "%givenName %familyName\\n%organization\\n%addressLine1\\n%addressLine2\\n%postalCode %locality",
+        "administrative_area_type": "oblast",
         "postcode_regex": "\\d{6}",
         "postcode_format": "######"
     },
@@ -2012,6 +2017,7 @@ COUNTRIES_DATA = {
         ],
         "population": 18276499,
         "format": "%postalCode\\n%administrativeArea\\n%locality\\n%addressLine1\\n%addressLine2\\n%organization\\n%givenName %familyName",
+        "administrative_area_type": "oblast",
         "postcode_regex": "\\d{6}",
         "postcode_format": "######"
     },
@@ -2279,7 +2285,7 @@ COUNTRIES_DATA = {
             "organization",
             "administrativeArea"
         ],
-        "administrative_area_type": "state",
+        "administrative_area_type": "island",
         "administrative_area_code": "ADM1",
         "postal_code_type": "zip",
         "postcode_regex": "(969[67]\\d)(?:[ \\-](\\d{4}))?",
@@ -2903,6 +2909,7 @@ COUNTRIES_DATA = {
             "locality",
             "postalCode"
         ],
+        "administrative_area_type": "voivodeship",
         "administrative_area_code": "ADM1",
         "postcode_regex": "\\d{2}-\\d{3}",
         "postcode_format": "##-###"
@@ -3158,7 +3165,7 @@ COUNTRIES_DATA = {
             "addressLine2",
             "locality"
         ],
-        "administrative_area_type": "oblast",
+        "administrative_area_type": "federal subject",
         "administrative_area_code": "ADM1",
         "subdivision_depth": 1,
         "postcode_regex": "\\d{6}",
@@ -3792,7 +3799,7 @@ COUNTRIES_DATA = {
             "organization",
             "administrativeArea"
         ],
-        "administrative_area_type": "state",
+        "administrative_area_type": "island",
         "administrative_area_code": "ADM1",
         "postal_code_type": "zip",
         "postcode_regex": "96898",
@@ -3943,7 +3950,7 @@ COUNTRIES_DATA = {
             "organization",
             "administrativeArea"
         ],
-        "administrative_area_type": "state",
+        "administrative_area_type": "island",
         "administrative_area_code": "ADM1",
         "postal_code_type": "zip",
         "postcode_regex": "(008(?:(?:[0-4]\\d)|(?:5[01])))(?:[ \\-](\\d{4}))?",
@@ -4094,6 +4101,38 @@ COUNTRIES_DATA = {
         "postcode_regex": "",
         "postcode_format": ""
     }
+}
+
+
+SUBREGION_TYPES = {
+    # Hong Kong
+    'area': pgettext_lazy("administrative area type", "area"),
+    # United Kingdom
+    'country': pgettext_lazy("administrative area type", "country"),
+    'county': pgettext_lazy("administrative area type", "county"),
+    'department': pgettext_lazy("administrative area type", "department"),
+    'district': pgettext_lazy("administrative area type", "district"),
+    # South Korea
+    'do_si': pgettext_lazy("administrative area type", "province / city"),
+    # United Arab Emirates
+    'emirate': pgettext_lazy("administrative area type", "emirate"),
+    # Bosnia and Herzegovina
+    'entity': pgettext_lazy("administrative area type", "entity"),
+    # Austria, Germany
+    'federal state': pgettext_lazy("administrative area type", "federal state"),
+    # Russia
+    'federal subject': pgettext_lazy("administrative area type", "federal subject"),
+    'governorate': pgettext_lazy("administrative area type", "governorate"),
+    'island': pgettext_lazy("administrative area type", "island"),
+    # Belorus, Bulgaria, Kazakhstan, Kyrgyzstan, Ukraine
+    'oblast': pgettext_lazy("administrative area type", "oblast"),
+    'parish': pgettext_lazy("administrative area type", "parish"),
+    # Japan
+    'prefecture': pgettext_lazy("administrative area type", "prefecture"),
+    'region': pgettext_lazy("administrative area type", "region"),
+    'state': pgettext_lazy("administrative area type", "state"),
+    # Poland
+    'voivodeship': pgettext_lazy("administrative area type", "voivodeship"),
 }
 
 

--- a/hosting/forms/places.py
+++ b/hosting/forms/places.py
@@ -15,7 +15,9 @@ from core.utils import join_lazy, mark_safe_lazy
 from maps import SRID
 from maps.widgets import MapboxGlWidget
 
-from ..countries import COUNTRIES_DATA, countries_with_mandatory_region
+from ..countries import (
+    COUNTRIES_DATA, SUBREGION_TYPES, countries_with_mandatory_region,
+)
 from ..models import LOCATION_CITY, Place, Profile, Whereabouts
 from ..utils import geocode, geocode_city
 from ..validators import TooNearPastValidator
@@ -54,6 +56,15 @@ class PlaceForm(forms.ModelForm):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
+
+        place_country = self.data.get('country') or self.instance.country
+        if place_country and place_country in COUNTRIES_DATA:
+            country_data = COUNTRIES_DATA[place_country]
+            region_type = country_data.get('administrative_area_type')
+            if region_type in SUBREGION_TYPES:
+                self.fields['state_province'].label = SUBREGION_TYPES[region_type].capitalize()
+                self.fields['state_province'].localised_label = True
+
         self.fields['address'].widget.attrs['rows'] = 2
         self.fields['conditions'].widget.attrs['data-placeholder'] = _("Choose your conditions...")
 

--- a/hosting/forms/places.py
+++ b/hosting/forms/places.py
@@ -20,7 +20,7 @@ from maps.widgets import MapboxGlWidget
 from ..countries import (
     COUNTRIES_DATA, SUBREGION_TYPES, countries_with_mandatory_region,
 )
-from ..models import LOCATION_CITY, CountryRegion, Place, Profile, Whereabouts
+from ..models import CountryRegion, LocationType, Place, Profile, Whereabouts
 from ..utils import geocode, geocode_city
 from ..validators import TooNearPastValidator
 
@@ -240,7 +240,7 @@ class PlaceForm(forms.ModelForm):
             if self.cleaned_data.get('city') != '':
                 # Create a new geocoding of the user's city if we don't have it in the database yet.
                 geocities = Whereabouts.objects.filter(
-                    type=LOCATION_CITY,
+                    type=LocationType.CITY,
                     name=self.cleaned_data['city'].upper(),
                     country=self.cleaned_data['country'],
                 )
@@ -257,7 +257,7 @@ class PlaceForm(forms.ModelForm):
                     )
                     if city_location:
                         Whereabouts.objects.create(
-                            type=LOCATION_CITY,
+                            type=LocationType.CITY,
                             name=self.cleaned_data['city'].upper(),
                             state=region,
                             country=self.cleaned_data['country'],

--- a/hosting/models.py
+++ b/hosting/models.py
@@ -1,6 +1,7 @@
 import re
 from collections import namedtuple
 from datetime import date
+from enum import Enum
 from functools import partial, partialmethod
 
 from django.apps import apps
@@ -55,7 +56,7 @@ TITLE_CHOICES = (
     (MR, _("Mr")),
 )
 
-PRONOUN_CHOICES = (
+PRONOUN_CHOICES = (  # In Django 3.x: TextChoices enum.
     (None, ""),
     ('She', pgettext_lazy("Personal Pronoun", "she")),
     ('He', pgettext_lazy("Personal Pronoun", "he")),
@@ -77,11 +78,14 @@ PHONE_TYPE_CHOICES = (
     (FAX, _("fax")),
 )
 
-LOCATION_CITY, LOCATION_REGION = 'C', 'R'
-WHEREABOUTS_TYPE_CHOICES = (
-    (LOCATION_CITY, _("City")),
-    (LOCATION_REGION, _("State / Province")),
-)
+
+class LocationType(Enum):
+    CITY = 'C'
+    REGION = 'R'
+    UNKNOWN = 'U'
+
+    def __str__(member):
+        return member.value
 
 
 class TrackingModel(models.Model):
@@ -1082,6 +1086,11 @@ class CountryRegion(models.Model):
 
 
 class Whereabouts(models.Model):
+    WHEREABOUTS_TYPE_CHOICES = (
+        (LocationType.CITY.value, _("City")),
+        (LocationType.REGION.value, _("State / Province")),
+    )
+
     type = models.CharField(
         _("location type"),
         max_length=1,

--- a/hosting/templates/hosting/place_form.html
+++ b/hosting/templates/hosting/place_form.html
@@ -55,6 +55,8 @@
 
 {% block form_after %}
     <script type="text/javascript">
-        $('#id_conditions, #id_country').chosen({no_results_text: "{% trans "Nothing found for" %}",});
+        $('#id_conditions, #id_country, select#id_state_province').chosen(
+            {no_results_text: "{% trans "Nothing found for" %}"}
+        );
     </script>
 {% endblock form_after %}

--- a/hosting/utils.py
+++ b/hosting/utils.py
@@ -10,7 +10,9 @@ from django.utils.deconstruct import deconstructible
 import geocoder
 
 from core.models import SiteConfiguration
-from maps import COUNTRIES_WITH_MANDATORY_REGION, SRID
+from maps import SRID
+
+from .countries import countries_with_mandatory_region
 
 
 def geocode(query, country='', private=False, annotations=False, multiple=False):
@@ -35,7 +37,7 @@ def geocode(query, country='', private=False, annotations=False, multiple=False)
 def geocode_city(cityname, country, state_province=None):
     if state_province:
         attempts = (', '.join([cityname, state_province]), )
-        if country not in COUNTRIES_WITH_MANDATORY_REGION:
+        if country not in countries_with_mandatory_region():
             attempts += (cityname, )
     else:
         attempts = (cityname, )

--- a/hosting/views/places.py
+++ b/hosting/views/places.py
@@ -27,9 +27,10 @@ from core.forms import UserRegistrationForm
 from core.models import SiteConfiguration
 from core.templatetags.utils import next_link
 from core.utils import sanitize_next
-from maps import COUNTRIES_WITH_MANDATORY_REGION, SRID
+from maps import SRID
 from maps.utils import bufferize_country_boundaries
 
+from ..countries import countries_with_mandatory_region
 from ..forms import (
     PlaceBlockForm, PlaceBlockQuickForm, PlaceCreateForm, PlaceForm,
     PlaceLocationForm, UserAuthorizedOnceForm, UserAuthorizeForm,
@@ -157,7 +158,7 @@ class PlaceDetailView(AuthMixin, PlaceMixin, generic.DetailView):
             location_type = 'R'  # = Region.
             geocities = Whereabouts.objects.filter(
                 type=LOCATION_CITY, name=place.city.upper(), country=place.country)
-            if place.country in COUNTRIES_WITH_MANDATORY_REGION:
+            if place.country in countries_with_mandatory_region():
                 geocities = geocities.filter(state=place.state_province.upper())
             try:
                 city_location = geocities.get()

--- a/hosting/views/places.py
+++ b/hosting/views/places.py
@@ -35,7 +35,7 @@ from ..forms import (
     PlaceBlockForm, PlaceBlockQuickForm, PlaceCreateForm, PlaceForm,
     PlaceLocationForm, UserAuthorizedOnceForm, UserAuthorizeForm,
 )
-from ..models import LOCATION_CITY, Place, Profile, TravelAdvice, Whereabouts
+from ..models import LocationType, Place, Profile, TravelAdvice, Whereabouts
 from .mixins import (
     CreateMixin, DeleteMixin, PlaceMixin, PlaceModifyMixin,
     ProfileIsUserMixin, ProfileModifyMixin, UpdateMixin,
@@ -157,7 +157,7 @@ class PlaceDetailView(AuthMixin, PlaceMixin, generic.DetailView):
         if (location is None or location.empty) and is_authenticated:
             location_type = 'R'  # = Region.
             geocities = Whereabouts.objects.filter(
-                type=LOCATION_CITY, name=place.city.upper(), country=place.country)
+                type=LocationType.CITY, name=place.city.upper(), country=place.country)
             if place.country in countries_with_mandatory_region():
                 geocities = geocities.filter(state=place.state_province.upper())
             try:

--- a/locale/eo/LC_MESSAGES/django.po
+++ b/locale/eo/LC_MESSAGES/django.po
@@ -1035,10 +1035,15 @@ msgstr "lokigo havebla"
 
 #, python-brace-format
 msgid ""
-"For an address in {country}, the name of the state or province must be "
+"For a city in {country}, the ISO code of the state or province must be "
 "indicated."
 msgstr ""
-"Adreso en {country} devas inkluzivi la nomon de la ŝtato aŭ de la provinco."
+"Por urbo en {country}, la ISO-kodo de la ŝtato aŭ de la provinco devas esti "
+"indikita."
+
+msgid ""
+"The 'state / province' field should indicate the ISO code of the region."
+msgstr "La kampo ‘ŝtato / provinco’ devas indiki la ISO-kodon de la regiono."
 
 msgid "confirmed on"
 msgstr "konfirmita je"
@@ -1139,8 +1144,23 @@ msgstr ""
 msgid "You already have this telephone number."
 msgstr "Vi jam indikis tian telefonnumeron."
 
+msgid "Choose from the list. The name provided by you is not known."
+msgstr "Elektu el la listo. La provizita de vi nomo ne estas inter la konataj."
+
 msgid "Choose your conditions..."
 msgstr "Elektu viajn kondiĉojn…"
+
+#, python-brace-format
+msgid ""
+"For an address in {country}, the name of the {region_type} must be indicated."
+msgstr "Adreso en {country} devas inkluzivi la nomon de la {region_type}."
+
+#, python-brace-format
+msgid ""
+"For an address in {country}, the name of the state or province must be "
+"indicated."
+msgstr ""
+"Adreso en {country} devas inkluzivi la nomon de la ŝtato aŭ de la provinco."
 
 msgid "Postal code should follow the pattern {} (# is digit, @ is a letter)."
 msgstr "Poŝtkodo devas laŭi la skemon {} (# estas cifero, @ estas litero)."

--- a/locale/eo/LC_MESSAGES/django.po
+++ b/locale/eo/LC_MESSAGES/django.po
@@ -1049,6 +1049,78 @@ msgstr "forigita"
 msgid "Hosting Service"
 msgstr "Gastiga Servo"
 
+msgctxt "administrative area type"
+msgid "area"
+msgstr "regiono"
+
+msgctxt "administrative area type"
+msgid "country"
+msgstr "graflando"
+
+msgctxt "administrative area type"
+msgid "county"
+msgstr "distrikto"
+
+msgctxt "administrative area type"
+msgid "department"
+msgstr "departemento"
+
+msgctxt "administrative area type"
+msgid "district"
+msgstr "distrikto"
+
+msgctxt "administrative area type"
+msgid "province / city"
+msgstr "provinco / urbo"
+
+msgctxt "administrative area type"
+msgid "emirate"
+msgstr "emirlando"
+
+msgctxt "administrative area type"
+msgid "entity"
+msgstr "landoparto"
+
+msgctxt "administrative area type"
+msgid "federal state"
+msgstr "federacia lando"
+
+msgctxt "administrative area type"
+msgid "federal subject"
+msgstr "federacia subjekto"
+
+msgctxt "administrative area type"
+msgid "governorate"
+msgstr "gubernio"
+
+msgctxt "administrative area type"
+msgid "island"
+msgstr "insulo"
+
+msgctxt "administrative area type"
+msgid "oblast"
+msgstr "provinco (oblasto)"
+
+msgctxt "administrative area type"
+msgid "parish"
+msgstr "distrikto"
+
+msgctxt "administrative area type"
+msgid "prefecture"
+msgstr "gubernio (prefektujo)"
+
+msgctxt "administrative area type"
+msgid "region"
+msgstr "regiono"
+
+msgctxt "administrative area type"
+msgid "state"
+msgstr "ŝtato"
+
+msgctxt "administrative area type"
+msgid "voivodeship"
+msgstr "provinco (vojevodio)"
+
 msgid "A family member cannot be future-born (even if planned)."
 msgstr "Kunloĝanto ne povas naskiĝi estontece, eĉ se planita."
 

--- a/maps/__init__.py
+++ b/maps/__init__.py
@@ -1,5 +1,2 @@
-from .data import (  # noqa:F401
-    COUNTRIES_WITH_MANDATORY_REGION, COUNTRIES_WITH_REGIONS,
-)
 
 SRID = 4326

--- a/maps/data.py
+++ b/maps/data.py
@@ -4000,9 +4000,3 @@ COUNTRIES_WITH_NO_BUFFER = (
     'GD', 'GG', 'HM', 'IM', 'JE', 'JM', 'KM', 'KN', 'LC', 'MS', 'MT', 'NR', 'NU',
     'SH', 'ST', 'TT', 'TW', 'VA', 'VC', 'VG', 'WS',
 )
-
-
-# TODO: Temporary solution, should be extracted from database (alongside biggest cities, etc.)
-COUNTRIES_WITH_MANDATORY_REGION = ('BR', 'CA', 'RU', 'US')
-
-COUNTRIES_WITH_REGIONS = ('BE', 'BR', 'CA', 'DE', 'FR', 'GB', 'US')

--- a/maps/management/commands/update_cities_geodata.py
+++ b/maps/management/commands/update_cities_geodata.py
@@ -6,7 +6,7 @@ from django.db.models import (
 from django.utils.termcolors import make_style
 
 from hosting.countries import countries_with_mandatory_region
-from hosting.models import LOCATION_CITY, Place, Whereabouts
+from hosting.models import LocationType, Place, Whereabouts
 from hosting.utils import geocode_city
 
 from ... import SRID
@@ -28,7 +28,7 @@ class Command(BaseCommand):
             .annotate(lookup=dbf.Concat(
                 'name', V('###'), 'state', V('###'), 'country',
                 output_field=CharField()))
-            .filter(type=LOCATION_CITY)
+            .filter(type=LocationType.CITY)
             .values_list('lookup', flat=True)
         )
         city_list = (
@@ -55,7 +55,7 @@ class Command(BaseCommand):
                     place.city, state_province=place.state_province, country=place.country.code)
                 if city_location:
                     whereabouts = Whereabouts.objects.create(
-                        type=LOCATION_CITY,
+                        type=LocationType.CITY,
                         name=place.city.upper(),
                         state=(
                             place.state_province.upper()

--- a/pasportaservo/settings/base.py
+++ b/pasportaservo/settings/base.py
@@ -157,14 +157,22 @@ LOGGING = {
     'version': 1,
     'disable_existing_loggers': False,
     'handlers': {
-        'mail_admins': {
+        'mail_admins_important_bits': {
             'level': 'WARNING',
             'class': 'django.utils.log.AdminEmailHandler',
-        }
+        },
+        'mail_admins_severe_bits': {
+            'level': 'ERROR',
+            'class': 'django.utils.log.AdminEmailHandler',
+        },
     },
     'loggers': {
+        'PasportaServo': {
+            'handlers': ['mail_admins_severe_bits'],
+        },
         'PasportaServo.auth': {
-            'handlers': ['mail_admins'],
+            'handlers': ['mail_admins_important_bits'],
+            'propagate': False,
         },
     },
 }

--- a/pasportaservo/settings/dev.py
+++ b/pasportaservo/settings/dev.py
@@ -1,5 +1,6 @@
 from .base import *  # isort:skip
 import logging
+import socket
 
 from django.contrib.messages import constants as message_level
 
@@ -15,6 +16,12 @@ ALLOWED_HOSTS = [
     'localhost',
     '127.0.0.1',
 ]
+try:
+    with socket.socket(socket.AF_INET, socket.SOCK_DGRAM) as s:
+        s.connect(('10.0.0.10', 0))
+        ALLOWED_HOSTS.append(s.getsockname()[0])
+except (OSError, IndexError):
+    pass
 
 
 logging.getLogger('PasportaServo.auth').setLevel(logging.INFO)

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -236,7 +236,7 @@ class CountryRegionFactory(DjangoModelFactory):
         short_code = factory.LazyFunction(lambda: random() < 0.20)
 
     country = factory.LazyFunction(lambda: Country(choice(list(COUNTRIES))))
-    iso_code = Faker('pystr_format', string_format='??#', letters='ABCDEFGHJKLMNPQRSTUVWXYZ')
+    iso_code = Faker('pystr_format', string_format='???#', letters='ABCDEFGHJKLMNPQRSTUVWXYZ')
     latin_code = factory.Maybe(
         'short_code',
         yes_declaration=Faker('pystr_format', string_format='??', letters='ABCDEFGHIJKLMNOPQRSTUVWXYZ'),

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -15,7 +15,7 @@ from slugify import slugify
 
 from hosting.countries import COUNTRIES_DATA, countries_with_mandatory_region
 from hosting.models import (
-    MR, MRS, PHONE_TYPE_CHOICES, PRONOUN_CHOICES, WHEREABOUTS_TYPE_CHOICES,
+    MR, MRS, PHONE_TYPE_CHOICES, PRONOUN_CHOICES, LocationType,
 )
 from maps import SRID
 from maps.data import COUNTRIES_GEO
@@ -268,7 +268,7 @@ class WhereaboutsFactory(DjangoModelFactory):
     class Meta:
         model = 'hosting.Whereabouts'
 
-    type = Faker('random_element', elements=[ch[0] for ch in WHEREABOUTS_TYPE_CHOICES])
+    type = Faker('random_element', elements=[ch.value for ch in LocationType])
 
     @factory.lazy_attribute
     def name(self):

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -13,11 +13,11 @@ from factory import DjangoModelFactory, Faker
 from phonenumber_field.phonenumber import PhoneNumber
 from slugify import slugify
 
-from hosting.countries import COUNTRIES_DATA
+from hosting.countries import COUNTRIES_DATA, countries_with_mandatory_region
 from hosting.models import (
     MR, MRS, PHONE_TYPE_CHOICES, PRONOUN_CHOICES, WHEREABOUTS_TYPE_CHOICES,
 )
-from maps import COUNTRIES_WITH_MANDATORY_REGION, SRID
+from maps import SRID
 from maps.data import COUNTRIES_GEO
 
 from .constants import PERSON_LOCALES
@@ -140,8 +140,9 @@ class PlaceFactory(DjangoModelFactory):
 
     @factory.lazy_attribute
     def state_province(self):
-        if self.country in COUNTRIES_WITH_MANDATORY_REGION or random() > 0.85:
-            return Faker('state').generate({})
+        if self.country in countries_with_mandatory_region() or random() > 0.85:
+            region = CountryRegionFactory(country=self.country)
+            return region.iso_code
         else:
             return ""
 
@@ -275,8 +276,8 @@ class WhereaboutsFactory(DjangoModelFactory):
 
     @factory.lazy_attribute
     def state(self):
-        if self.country in COUNTRIES_WITH_MANDATORY_REGION:
-            return Faker('state').generate({}).upper()
+        if self.country in countries_with_mandatory_region():
+            return CountryRegionFactory(country=self.country).iso_code
         else:
             return ""
 

--- a/tests/forms/test_phone_forms.py
+++ b/tests/forms/test_phone_forms.py
@@ -232,7 +232,7 @@ class PhoneFormTests(WebTest):
                 self.phone4_valid.pk,
             )
         )
-        self.assertEqual(self.phone4_valid.comments, comment)
+        self.assertEqual(self.phone4_valid.comments, comment.rstrip())
 
 
 class PhoneCreateFormTests(PhoneFormTests):
@@ -291,4 +291,4 @@ class PhoneCreateFormTests(PhoneFormTests):
             )
         )
         self.assertEqual(new_phone.number, number)
-        self.assertEqual(new_phone.comments, comment)
+        self.assertEqual(new_phone.comments, comment.rstrip())

--- a/tests/forms/test_place_forms.py
+++ b/tests/forms/test_place_forms.py
@@ -17,7 +17,7 @@ from hosting.countries import (
     COUNTRIES_DATA, SUBREGION_TYPES, countries_with_mandatory_region,
 )
 from hosting.forms.places import PlaceForm
-from hosting.models import LOCATION_CITY, Condition, CountryRegion, Whereabouts
+from hosting.models import Condition, CountryRegion, LocationType, Whereabouts
 from maps import SRID
 
 from ..assertions import AdditionalAsserts
@@ -651,7 +651,7 @@ class PlaceFormTests(AdditionalAsserts, WebTest):
             else:
                 countries = self.countries_no_predefined_region
             country = self.faker.random_element(elements=countries)
-            whereabouts = WhereaboutsFactory(type=LOCATION_CITY, country=country)
+            whereabouts = WhereaboutsFactory(type=LocationType.CITY, country=country)
             number_coded_cities = Whereabouts.objects.count()
 
             form_data = PlaceForm(instance=self.simple_place).initial.copy()

--- a/tests/models/test_countryregion_model.py
+++ b/tests/models/test_countryregion_model.py
@@ -1,9 +1,11 @@
-from django.test import TestCase, override_settings, tag
+from unittest.mock import PropertyMock, patch
+
+from django.test import TestCase, tag
 
 from ..factories import CountryRegionFactory
 
 
-@tag('models')
+@tag('models', 'subregions')
 class CountryRegionModelTests(TestCase):
     def test_field_max_lengths(self):
         region = CountryRegionFactory.build()
@@ -14,15 +16,91 @@ class CountryRegionModelTests(TestCase):
         self.assertEquals(region._meta.get_field('local_name').max_length, 70)
         self.assertEquals(region._meta.get_field('esperanto_name').max_length, 70)
 
-    @override_settings(LANGUAGE_CODE='en')
+    def test_display_value(self):
+        test_data = [
+            (
+                # For region with latin code and latin name, value is expected to be the latin name.
+                dict(latin_code="ABC", latin_name="Appa Balwant Chowk"),
+                "Appa Balwant Chowk"
+            ), (
+                # For region with only latin code and no latin name, value is expected to be the latin code.
+                dict(latin_code="Shaniwar Peth", latin_name=""),
+                "Shaniwar Peth"
+            ), (
+                # For region with latin code equal to the local code, value is expected to be only one of them.
+                dict(latin_code="Aundh", latin_name="", local_code="Aundh"),
+                "Aundh"
+            ), (
+                # For region with local code similar to the latin code, value is expected to be the local code.
+                dict(latin_code="Balewadi", latin_name="", local_code="Báłěwàďı"),
+                "Báłěwàďı"
+            ), (
+                # For region with local code, value is expected to be latin code with the local code.
+                dict(latin_code="Baner", latin_name="", local_code="बाणेर"),
+                "Baner (बाणेर)"
+            ), (
+                # For region with both local code and name, value is expected to be latin code with the local name.
+                dict(latin_code="Baner", latin_name="", local_code="BNR", local_name="बाणेर"),
+                "Baner (बाणेर)"
+            ), (
+                # For region with latin code equal to local code with addition of prefix or suffix,
+                # value is expected to be only the local code.
+                dict(latin_code="Neighbourhood of Bavdhan", latin_name="", local_code="Bavdhan"),
+                "Bavdhan"
+            ), (
+                # For region with latin code equal to local code minus a prefix or a suffix,
+                # value is expected to be only the local code.
+                dict(latin_code="Bavdhan", latin_name="", local_code="Bavdhan Localilty"),
+                "Bavdhan Localilty"
+            ), (
+                # For region with latin code similar to local code and with addition of prefix or suffix,
+                # value is expected to be both latin code with the local code.
+                dict(latin_code="Neighbourhood of Bavdhan", latin_name="", local_code="Bāvdhān"),
+                "Neighbourhood of Bavdhan (Bāvdhān)"
+            ), (
+                # For region with latin code similar to local code and minus a prefix or a suffix,
+                # value is expected to be both latin code with the local code.
+                dict(latin_code="Bavdhan", latin_name="", local_code="Bāvdhān Locality"),
+                "Bavdhan (Bāvdhān Locality)"
+            ), (
+                # For region with both latin code and name, and both local code and name,
+                # value is expected to be both latin name with the local name.
+                dict(latin_code="BH5", latin_name="Bhosari", local_code="05", local_name="भोसरी"),
+                "Bhosari (भोसरी)"
+            )
+        ]
+        for kwargs, expected_value in test_data:
+            for esperanto_name in ("", "Najbarejo"):
+                with self.subTest(**kwargs, esperanto=esperanto_name):
+                    region = CountryRegionFactory.build(**kwargs, esperanto_name=esperanto_name)
+                    if esperanto_name:
+                        self.assertEqual(
+                            region.get_display_value(),
+                            f"{esperanto_name} \xa0\u2013\xa0 {expected_value}"
+                        )
+                    else:
+                        self.assertEqual(region.get_display_value(), expected_value)
+
+        # The value is expected to be calculated only once and memoized.
+        region = CountryRegionFactory.build(short_code=False)
+        with patch('hosting.models.CountryRegion.latin_code', new_callable=PropertyMock) as mock_name:
+            result1 = region.get_display_value()
+            result2 = region.get_display_value()
+            mock_name.assert_called_once()
+            self.assertEqual(id(result1), id(result2))
+            region.latin_name = "Charholi Budruk"
+            result3 = region.get_display_value()
+            mock_name.assert_called_once()
+            self.assertEqual(id(result1), id(result3))
+
     def test_str(self):
         region = CountryRegionFactory.build(short_code=False)
-        self.assertEquals(
+        self.assertEqual(
             str(region),
             f"{region.country.code}: {region.latin_code}"
         )
         region = CountryRegionFactory.build(short_code=True)
-        self.assertEquals(
+        self.assertEqual(
             str(region),
             f"{region.country.code}: {region.latin_name} ({region.latin_code})"
         )

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -659,6 +659,7 @@ class GeographicUtilityFunctionsTests(AdditionalAsserts, TestCase):
         self.assertEqual(result.village, "Varsovia")
         self.assertEqual(result.xy, [-75.900398, 8.3816971])
 
+    @tag('subregions')
     def test_countries_with_mandatory_region(self):
         with self.assertRaises(UserWarning, msg="Result is not iterable."):
             try:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -19,6 +19,7 @@ from core.utils import (
     camel_case_split, is_password_compromised,
     join_lazy, send_mass_html_mail, sort_by,
 )
+from hosting.countries import countries_with_mandatory_region
 from hosting.gravatar import email_to_gravatar
 from hosting.utils import (
     geocode, geocode_city, split, title_with_particule,
@@ -657,6 +658,23 @@ class GeographicUtilityFunctionsTests(AdditionalAsserts, TestCase):
         self.assertEqual(result.city, "Monteria")
         self.assertEqual(result.village, "Varsovia")
         self.assertEqual(result.xy, [-75.900398, 8.3816971])
+
+    def test_countries_with_mandatory_region(self):
+        with self.assertRaises(UserWarning, msg="Result is not iterable."):
+            try:
+                iter(countries_with_mandatory_region())
+            except TypeError:
+                pass
+            else:
+                raise UserWarning
+        with patch('hosting.countries.frozenset') as mock_set_object:
+            countries = countries_with_mandatory_region()
+            # Validate that the cache is only populated once.
+            mock_set_object.assert_not_called()
+            # Validate that the contents are 2-character country codes.
+            self.assertTrue(
+                all(isinstance(c, str) and len(c) == 2 and c.isalpha() for c in countries)
+            )
 
     def test_bufferize_country_boundaries_unknown(self):
         self.assertIsNone(bufferize_country_boundaries('XYZ'))


### PR DESCRIPTION
Tria tirpeto el serio celanta reguligi diversajn aspektojn de la adresoj de loĝejoj. Tiu ĉi enkondukas kontrolon ke la indikita administra ero (subŝtato / provinco / distrikto / ks) estas difinita por la koncerna lando. La kampo ‘ŝtato_provinco’ en la loĝeja formularo estas dinamike ŝanĝita al elekto-listo por landoj por kiuj la administraj eroj estas konataj.