### PR TITLE
Plibonigo de rendimento – landaj organizantoj

### DIFF
--- a/hosting/forms/familymembers.py
+++ b/hosting/forms/familymembers.py
@@ -46,7 +46,7 @@ class FamilyMemberCreateForm(FamilyMemberForm):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
-    def save(self):
+    def save(self, **kwargs):
         family_member = super().save()
         self.place.family_members.add(family_member)
         return family_member

--- a/hosting/templates/hosting/place_list_supervisor.html
+++ b/hosting/templates/hosting/place_list_supervisor.html
@@ -347,7 +347,6 @@
                         </div>
                         <div class="phone-number-list">
                         {# LIST OF PHONE NUMBERS VIA WHICH THE OWNER IS REACHABLE #}
-                            {# TODO: Phones are re-fetched even though they are in a prefetch... #}
                             {% for phone in place.profile.phones.all %}
                                 {% if not phone.deleted %}
                                     <small class="phone-number">

--- a/tests/forms/test_familymember_forms.py
+++ b/tests/forms/test_familymember_forms.py
@@ -1,0 +1,386 @@
+from datetime import date, timedelta
+
+from django.test import override_settings, tag
+from django.urls import reverse
+
+import rstr
+from django_webtest import WebTest
+from faker import Faker
+
+from hosting.forms.familymembers import (
+    FamilyMemberCreateForm, FamilyMemberForm,
+)
+from hosting.models import MR, MRS
+
+from ..factories import PlaceFactory, ProfileSansAccountFactory
+
+
+@tag('forms', 'forms-familymembers', 'family-members')
+@override_settings(LANGUAGE_CODE='en')
+class FamilyMemberFormTests(WebTest):
+    form_class = FamilyMemberForm
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.faker = Faker()
+
+        cls.expected_fields = [
+            'first_name',
+            'last_name',
+            'names_inversed',
+            'title',
+            'birth_date',
+        ]
+
+        cls.place_with_family = PlaceFactory()
+        cls.profile_one = ProfileSansAccountFactory(pronoun="", description="")
+        cls.place_with_family.family_members.add(cls.profile_one)
+        # Verify that family member is stored and force populating cache.
+        assert len(cls.place_with_family.family_members_cache()) == 1
+        cls.place_anon_family = PlaceFactory()
+        cls.profile_two = ProfileSansAccountFactory(
+            first_name="", last_name="", pronoun="", description="")
+        cls.place_anon_family.family_members.add(cls.profile_two)
+        # Verify that family member is stored and force populating cache.
+        assert len(cls.place_anon_family.family_members_cache()) == 1
+
+    def setUp(self):
+        self.profile_one.refresh_from_db()
+        self.place_with_family.family_members_cache()[0].refresh_from_db()
+        self.profile_two.refresh_from_db()
+        self.place_anon_family.family_members_cache()[0].refresh_from_db()
+
+    def _init_form(self, data=None, place=None, member_index=0):
+        assert place is not None
+        assert member_index < len(place.family_members_cache())
+        return self.form_class(
+            data=data, instance=place.family_members_cache()[member_index], place=place)
+
+    def test_init(self):
+        with self.assertNumQueries(0):
+            form = self._init_form(place=self.place_with_family)
+        # Verify that the expected fields are part of the form.
+        self.assertEquals(set(self.expected_fields), set(form.fields))
+        # Verify that fields are not marked 'required'.
+        for field in self.expected_fields:
+            with self.subTest(field=field):
+                self.assertFalse(form.fields[field].required)
+        # Help text for 'regular' family is expected to be empty.
+        self.assertEqual(form.fields['first_name'].help_text, "")
+        self.assertEqual(form.fields['last_name'].help_text, "")
+        # Help text for 'anonymous' family is expected to be non-empty.
+        with self.assertNumQueries(0):
+            form = self._init_form(place=self.place_anon_family)
+        self.assertEqual(
+            form.fields['first_name'].help_text,
+            "Leave empty if you only want to indicate that "
+            "other people are present in the house."
+        )
+        # Verify that the form's save method is protected in templates.
+        self.assertTrue(
+            hasattr(form.save, 'alters_data')
+            or hasattr(form.save, 'do_not_call_in_templates')
+        )
+
+    def test_invalid_init(self):
+        # Form without an associated place is expected to be invalid.
+        with self.assertRaises(KeyError) as cm:
+            self.form_class({})
+        self.assertEqual(cm.exception.args[0], 'place')
+
+    def test_blank_data_for_regular_small_family(self):
+        # Empty form for member of place's 'regular' 1-person family is expected to be invalid.
+        with self.assertNumQueries(0):
+            form = self._init_form(data={}, place=self.place_with_family)
+            self.assertFalse(form.is_valid())
+        self.assertEqual(form.non_field_errors(), [
+            "The name cannot be empty, at least first name or last name are required."
+        ])
+
+    def test_blank_data_for_regular_big_family(self):
+        # Empty form for member of place's 'regular' 2-person family is expected to be invalid.
+        place_with_big_family = PlaceFactory()
+        place_with_big_family.family_members.add(self.profile_one)
+        place_with_big_family.family_members.add(ProfileSansAccountFactory())
+        with self.assertNumQueries(1):
+            form = self._init_form(data={}, place=place_with_big_family, member_index=0)
+            self.assertFalse(form.is_valid())
+        self.assertEqual(form.non_field_errors(), [
+            "The name cannot be empty, at least first name or last name are required."
+        ])
+
+    def test_blank_data_for_anonymous_family(self):
+        # Empty form for member of place's 'anonymous' family is expected to be valid.
+        with self.assertNumQueries(0):
+            form = self._init_form(data={}, place=self.place_anon_family)
+            self.assertTrue(form.is_valid(), msg=repr(form.errors))
+
+    def test_invalid_birth_date_in_past(self):
+        # An overly young (born in future) or a too old profile is expected to be invalid.
+        today = date.today()
+        try:
+            max_past = today.replace(year=today.year - 200)
+        except ValueError:
+            max_past = today.replace(year=today.year - 200, day=today.day - 1)
+        birth_date = max_past - timedelta(days=1)
+        form = self._init_form(
+            {
+                'first_name': self.faker.first_name(),
+                'last_name': self.faker.last_name(),
+                'birth_date': birth_date,
+            },
+            place=self.place_with_family)
+        self.assertFalse(form.is_valid())
+        self.assertIn('birth_date', form.errors)
+        self.assertEqual(form.errors, {
+            'birth_date': [f"Ensure this value is greater than or equal to {max_past}."],
+        })
+
+    def test_invalid_birth_date_in_future(self):
+        # An overly young (born in future) family member is expected to be invalid.
+        today = date.today()
+        birth_date = today + timedelta(days=1)
+        form = self._init_form(
+            {
+                'first_name': self.faker.first_name(),
+                'last_name': self.faker.last_name(),
+                'birth_date': birth_date,
+            },
+            place=self.place_with_family)
+        self.assertFalse(form.is_valid())
+        self.assertIn('birth_date', form.errors)
+        self.assertEqual(form.errors, {
+            'birth_date': ["A family member cannot be future-born (even if planned)."],
+        })
+
+    def test_valid_birth_date(self):
+        # A family member of any reasonable age is expected to be valid.
+        form = self._init_form(
+            {
+                'first_name': "Aaa",
+                'last_name': "Bbb",
+                'birth_date': self.faker.date_between(start_date='-99y', end_date=date.today()),
+            },
+            place=self.place_anon_family)
+        self.assertTrue(form.is_valid(), msg=repr(form.errors))
+        # A family member without a known age is expected to be valid.
+        form = self._init_form(
+            {
+                'first_name': "Ccc",
+                'last_name': "Ddd",
+            },
+            place=self.place_anon_family)
+        self.assertTrue(form.is_valid(), msg=repr(form.errors))
+
+    def test_invalid_names(self):
+        # A family member with names containing non-latin characters or digits
+        # is expected to be invalid.
+        test_data = (
+            (
+                "latin name",
+                lambda: Faker(locale='ja').name(),
+                "provide this data in Latin characters",
+            ), (
+                "symbols",
+                lambda: rstr.punctuation(2) + rstr.punctuation(4, 10, include=rstr.lowercase(4)),
+                "provide this data in Latin characters",
+            ), (
+                "digits",
+                lambda: rstr.lowercase(6, 12, include=rstr.digits()),
+                "Digits are not allowed",
+            ), (
+                "all caps",
+                lambda: rstr.uppercase(6, 12),
+                "Today is not CapsLock day",
+            ), (
+                "many caps",
+                lambda: rstr.uppercase(6, 12, include=rstr.lowercase(5)),
+                "there are too many uppercase letters",
+            ),
+        )
+
+        for field_violation, field_value, assert_content in test_data:
+            for wrong_field in ('first_name', 'last_name'):
+                with self.subTest(field=wrong_field, violation=field_violation):
+                    data = {
+                        wrong_field: field_value()
+                    }
+                    with self.subTest(value=data[wrong_field]):
+                        form = self._init_form(data, place=self.place_with_family)
+                        self.assertFalse(form.is_valid())
+                        self.assertIn(wrong_field, form.errors)
+                        self.assertTrue(
+                            any(assert_content in error for error in form.errors[wrong_field]),
+                            msg=repr(form.errors)
+                        )
+
+    def test_valid_names(self):
+        # A family member with only a first name or a last name is expected to be valid.
+        with self.subTest(name="first name"):
+            form = self._init_form(
+                {
+                    'first_name': Faker(locale='lt').first_name(),
+                    'last_name': "",
+                },
+                place=self.place_anon_family)
+            self.assertTrue(form.is_valid())
+        with self.subTest(name="last name"):
+            form = self._init_form(
+                {
+                    'first_name': "",
+                    'last_name': Faker(locale='lv').last_name(),
+                },
+                place=self.place_anon_family)
+            self.assertTrue(form.is_valid())
+
+    def test_invalid_title(self):
+        # A family member with an unrecognised title is expected to be invalid.
+        form = self._init_form(
+            {
+                'first_name': "Eee",
+                'last_name': "Ggg",
+                'title': "XYZ",
+            },
+            place=self.place_with_family)
+        self.assertFalse(form.is_valid())
+        self.assertIn('title', form.errors)
+        self.assertEqual(form.errors, {
+            'title': ["Select a valid choice. XYZ is not one of the available choices."],
+        })
+
+    def test_valid_data(self, for_place=None):
+        data = {
+            'first_name': Faker(locale='lt').first_name(),
+            'last_name': Faker(locale='lv').last_name(),
+            'names_inversed': True,
+            'birth_date': self.faker.date_between(start_date='-99y', end_date=date.today()),
+            'title': self.faker.random_element(elements=[MRS, MR]),
+        }
+        place = for_place or self.place_with_family
+        form = self._init_form(data, place=place)
+        self.assertTrue(form.is_valid(), msg=repr(form.errors))
+        profile = form.save(commit=False)
+        if type(form) is FamilyMemberForm:
+            self.assertEqual(profile.pk, self.profile_one.pk)
+        elif type(form) is FamilyMemberCreateForm:
+            self.assertNotEqual(profile.pk, self.profile_one.pk)
+        self.assertEqual(len(place.family_members.all()), 1)
+        self.assertEqual(profile.first_name, data['first_name'])
+        self.assertEqual(profile.last_name, data['last_name'])
+        self.assertTrue(profile.names_inversed)
+        self.assertEqual(profile.title, data['title'])
+        self.assertIsNone(profile.gender)
+        self.assertEqual(profile.pronoun, "")
+        self.assertEqual(profile.birth_date, data['birth_date'])
+        self.assertEqual(profile.description, "")
+
+    def test_view_page(self):
+        page = self.app.get(
+            reverse('family_member_update', kwargs={
+                'pk': self.profile_one.pk,
+                'place_pk': self.place_with_family.pk}),
+            user=self.place_with_family.owner.user,
+        )
+        self.assertEqual(page.status_code, 200)
+        self.assertEqual(len(page.forms), 1)
+        self.assertIs(type(page.context['form']), self.form_class)
+
+    def test_form_submit(self):
+        page = self.app.get(
+            reverse('family_member_update', kwargs={
+                'pk': self.profile_one.pk,
+                'place_pk': self.place_with_family.pk}),
+            user=self.place_with_family.owner.user,
+        )
+        page.form['first_name'] = fname = Faker(locale='et').first_name()
+        page.form['last_name'] = lname = Faker(locale='fi').last_name()
+        page = page.form.submit()
+        self.profile_one.refresh_from_db()
+        self.assertRedirects(
+            page,
+            reverse('profile_edit', kwargs={
+                'pk': self.place_with_family.owner.pk,
+                'slug': self.place_with_family.owner.autoslug})
+        )
+        self.assertEqual(self.profile_one.first_name, fname)
+        self.assertEqual(self.profile_one.last_name, lname)
+
+
+class FamilyMemberCreateFormTests(FamilyMemberFormTests):
+    form_class = FamilyMemberCreateForm
+
+    def _init_form(self, data=None, place=None, member_index=0):
+        assert place is not None
+        return self.form_class(data=data, place=place)
+
+    def test_blank_data_for_no_family(self):
+        # Empty form for first member of place's family is expected to be valid.
+        place_no_family = PlaceFactory()
+        with self.assertNumQueries(1):
+            form = self._init_form(data={}, place=place_no_family)
+            self.assertTrue(form.is_valid(), msg=repr(form.errors))
+
+    def test_valid_data(self, for_place=None):
+        super().test_valid_data(for_place or PlaceFactory())
+
+    def test_view_page(self):
+        page = self.app.get(
+            reverse('family_member_create', kwargs={
+                'place_pk': self.place_with_family.pk}),
+            user=self.place_with_family.owner.user,
+        )
+        self.assertEqual(page.status_code, 200)
+        self.assertEqual(len(page.forms), 1)
+        self.assertIs(type(page.context['form']), self.form_class)
+
+    def test_form_submit(self):
+        place_with_family = PlaceFactory()
+        profile_old = ProfileSansAccountFactory()
+        place_with_family.family_members.add(profile_old)
+
+        page = self.app.get(
+            reverse('family_member_create', kwargs={
+                'place_pk': place_with_family.pk}),
+            user=place_with_family.owner.user,
+        )
+        page.form['first_name'] = fname = Faker(locale='et').first_name()
+        page.form['last_name'] = lname = Faker(locale='fi').last_name()
+        page.form['title'] = MR
+        page = page.form.submit()
+        self.assertRedirects(
+            page,
+            reverse('profile_edit', kwargs={
+                'pk': place_with_family.owner.pk,
+                'slug': place_with_family.owner.autoslug})
+        )
+
+        profile_new = place_with_family.family_members.last()
+        self.assertNotEqual(profile_old.pk, profile_new.pk)
+        self.assertEqual(profile_new.first_name, fname)
+        self.assertEqual(profile_new.last_name, lname)
+        self.assertEqual(profile_new.birth_date, None)
+        self.assertEqual(profile_new.title, MR)
+
+    def test_form_submit_anonymous_family(self):
+        place_no_family = PlaceFactory()
+
+        page = self.app.get(
+            reverse('family_member_create', kwargs={
+                'place_pk': place_no_family.pk}),
+            user=place_no_family.owner.user,
+        )
+        page.form['title'] = MRS
+        page = page.form.submit()
+        self.assertRedirects(
+            page,
+            reverse('profile_edit', kwargs={
+                'pk': place_no_family.owner.pk,
+                'slug': place_no_family.owner.autoslug})
+        )
+
+        family = place_no_family.family_members.all()
+        self.assertEqual(len(family), 1)
+        self.assertEqual(family[0].first_name, "")
+        self.assertEqual(family[0].last_name, "")
+        self.assertEqual(family[0].birth_date, None)
+        self.assertEqual(family[0].title, MRS)


### PR DESCRIPTION
Uzado de datumkunmetado ene de la datumbazo mem kaj reuzo de la jam-ŝargitaj datenoj, anstataŭ ripetaj petoj kun diversaj kondiĉoj, aldone al kaŝmemorigo de informoj, signife malpliigas la nombron de datumbazaj petoj.